### PR TITLE
new: Layout widget

### DIFF
--- a/aiogram_dialog/widgets/kbd/group.py
+++ b/aiogram_dialog/widgets/kbd/group.py
@@ -1,5 +1,6 @@
-from itertools import chain
-from typing import List, Dict, Optional
+from itertools import chain, islice, accumulate
+from operator import itemgetter
+from typing import List, Dict, Optional, Sequence, Union, Callable
 
 from aiogram.types import InlineKeyboardButton, CallbackQuery
 
@@ -7,6 +8,14 @@ from aiogram_dialog.dialog import Dialog
 from aiogram_dialog.manager.manager import DialogManager
 from .base import Keyboard
 from ..when import WhenCondition
+
+ItemsGetter = Callable[[Dict], Sequence]
+
+
+def get_identity(items: Sequence) -> ItemsGetter:
+    def identity(data) -> Sequence:
+        return items
+    return identity
 
 
 class Group(Keyboard):
@@ -49,6 +58,61 @@ class Group(Keyboard):
         if row:
             res.append(row)
         return res
+
+    async def process_callback(self, c: CallbackQuery, dialog: Dialog, manager: DialogManager) -> bool:
+        for b in self.buttons:
+            if await b.process_callback(c, dialog, manager):
+                return True
+        return False
+
+
+class Layout(Keyboard):
+    def __init__(self,
+                 *buttons: Keyboard,
+                 id: Optional[str] = None,
+                 layout: Union[str, Sequence] = None,
+                 when: WhenCondition = None):
+        super().__init__(id, when)
+        self.buttons = buttons
+
+        if isinstance(layout, str):
+            self.layout_getter = itemgetter(layout)
+        elif layout is None:
+            self.layout_getter = lambda x: None
+        else:
+            self.layout_getter = get_identity(layout)
+
+    def find(self, widget_id):
+        widget = super(Layout, self).find(widget_id)
+        if widget:
+            return widget
+        for btn in self.buttons:
+            widget = btn.find(widget_id)
+            if widget:
+                return widget
+        return None
+
+    async def _render_keyboard(self, data: Dict, manager: DialogManager) -> List[List[InlineKeyboardButton]]:
+        kbd: List[List[InlineKeyboardButton]] = []
+        layout = self.layout_getter(data)
+
+        for b in self.buttons:
+            b_kbd = await b.render_keyboard(data, manager)
+            if layout is None or not kbd:
+                kbd += b_kbd
+            else:
+                kbd[0].extend(chain.from_iterable(b_kbd))
+
+        if layout and kbd:
+            kbd = list(self._wrap_kbd(kbd[0], layout))
+        return kbd
+
+    def _wrap_kbd(self, kbd: List[InlineKeyboardButton], layout: Sequence) -> List[List[InlineKeyboardButton]]:
+        _layout = list(accumulate(layout))
+
+        for start, end in zip([0, *_layout],
+                              [*_layout, _layout[-1]]):
+            yield list(islice(kbd, start, end))
 
     async def process_callback(self, c: CallbackQuery, dialog: Dialog, manager: DialogManager) -> bool:
         for b in self.buttons:


### PR DESCRIPTION
Layout widget added

Returns rows with predefined number of buttons.
Layout with layout=(1, 2, 3) returns the same as:

> Row(buttons[:1]),
> Row(buttons[1:3]),
> Row(buttons[3:6])

'layout' value should be defined in getter, feel free to suggest a better name

Copied get_identity, ItemsGetter in compliancy with select, list modules (both has own objects)
I also suggest thinking about merging Layout and Group in one object.