### PR TITLE
Add magic-filter support for Whenable widgets

### DIFF
--- a/aiogram_dialog/widgets/when.py
+++ b/aiogram_dialog/widgets/when.py
@@ -1,9 +1,10 @@
 from typing import Union, Callable, Dict
 
 from aiogram_dialog.manager.manager import DialogManager
+from magic_filter import MagicFilter
 
 Predicate = Callable[[Dict, "Whenable", DialogManager], bool]
-WhenCondition = Union[str, Predicate, None]
+WhenCondition = Union[str, MagicFilter, Predicate, None]
 
 
 def new_when_field(fieldname: str) -> Predicate:
@@ -11,6 +12,13 @@ def new_when_field(fieldname: str) -> Predicate:
         return bool(data.get(fieldname))
 
     return when_field
+
+
+def new_when_magic(f: MagicFilter) -> Predicate:
+    def when_magic(data: Dict, widget: "Whenable", manager: DialogManager) -> bool:
+        return f.resolve(data)
+
+    return when_magic
 
 
 def true(data: Dict, widget: "Whenable", manager: DialogManager):
@@ -25,6 +33,8 @@ class Whenable:
             self.condition = true
         elif isinstance(when, str):
             self.condition = new_when_field(when)
+        elif isinstance(when, MagicFilter):
+            self.condition = new_when_magic(when)
         else:
             self.condition = when
 

--- a/aiogram_dialog/widgets/when.py
+++ b/aiogram_dialog/widgets/when.py
@@ -1,7 +1,8 @@
 from typing import Union, Callable, Dict
 
-from aiogram_dialog.manager.manager import DialogManager
 from magic_filter import MagicFilter
+
+from aiogram_dialog.manager.manager import DialogManager
 
 Predicate = Callable[[Dict, "Whenable", DialogManager], bool]
 WhenCondition = Union[str, MagicFilter, Predicate, None]

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'aiogram>=2.12,<3',
         'jinja2',
         'cachetools==4.*',
+        'magic_filter',
     ],
     extras_require={
         "tools": [


### PR DESCRIPTION
Add [magic-filter](https://github.com/aiogram/magic-filter/) support.
Use case example:
```python3
async def get_data(dialog_manager: DialogManager, **kwargs):
    return {"user": dialog_manager.event.from_user}

Window(
    Format("Hello, @{username}", when=F["user"].username),
    Format("Hello, an unknown user", when=~F["user"].username),
    Format("You're the admin", when=F["user"].id == ADMIN_ID),
    getter=get_data,
)
```