### PR TITLE
Patch for poetry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     ],
     packages=find_packages(include=['aiogram_dialog', 'aiogram_dialog.*']),
     install_requires=[
-        'aiogram==3.*',
+        'aiogram>=3.0.0b1,<4.0.0',
         'jinja2',
         'cachetools==4.*',
         'magic_filter',


### PR DESCRIPTION
This patch fixes the error when Poetry tries to find `aiogram>=4.0.0,<5.0.0`