### PR TITLE
bug setting value on start dialog in checkbox widget fix

### DIFF
--- a/aiogram_dialog/widgets/kbd/checkbox.py
+++ b/aiogram_dialog/widgets/kbd/checkbox.py
@@ -69,10 +69,11 @@ class BaseCheckbox(Keyboard, ABC):
 
 class Checkbox(BaseCheckbox):
     def __init__(self, checked_text: Text, unchecked_text: Text, id: str,
+                 on_click: Union[OnStateChanged, WidgetEventProcessor, None] = None,
                  on_state_changed: Optional[OnStateChanged] = None,
                  default: bool = False,
                  when: Union[str, Callable] = None):
-        super().__init__(checked_text, unchecked_text, id, on_state_changed,
+        super().__init__(checked_text, unchecked_text, id, on_click, on_state_changed,
                          when)
         self.default = default
 


### PR DESCRIPTION
The bug was in missing parameter that was inherited from the parent class.