### PR TITLE
Fix `MessageInput` examples and type hint

### DIFF
--- a/aiogram_dialog/widgets/input/base.py
+++ b/aiogram_dialog/widgets/input/base.py
@@ -15,7 +15,7 @@ from aiogram_dialog.widgets.widget_event import (
 )
 
 MessageHandlerFunc = Callable[
-    [Message, DialogProtocol, DialogManager],
+    [Message, "MessageInput", DialogManager],
     Awaitable,
 ]
 

--- a/example/multistack.py
+++ b/example/multistack.py
@@ -11,7 +11,7 @@ from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.types import Message, CallbackQuery
 
 from aiogram_dialog import (
-    Dialog, DialogManager, DialogProtocol, DialogRegistry, StartMode, Window,
+    Dialog, DialogManager, DialogRegistry, StartMode, Window,
 )
 from aiogram_dialog.widgets.input import MessageInput
 from aiogram_dialog.widgets.kbd import Button, Cancel, Multiselect, Start
@@ -41,7 +41,7 @@ async def get_data(dialog_manager: DialogManager, **kwargs):
 
 
 async def name_handler(
-        message: Message, dialog: DialogProtocol, manager: DialogManager,
+        message: Message, message_input: MessageInput, manager: DialogManager,
 ):
     manager.dialog_data["last_text"] = message.text
     await message.answer(f"Nice to meet you, {message.text}")

--- a/example/simple.py
+++ b/example/simple.py
@@ -10,7 +10,7 @@ from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.types import Message, CallbackQuery, ContentType
 
 from aiogram_dialog import (
-    Dialog, DialogManager, DialogProtocol, DialogRegistry,
+    Dialog, DialogManager, DialogRegistry,
     ChatEvent, StartMode, Window,
 )
 from aiogram_dialog.api.exceptions import UnknownIntent
@@ -39,7 +39,7 @@ async def get_data(dialog_manager: DialogManager, **kwargs):
     }
 
 
-async def name_handler(message: Message, dialog: DialogProtocol,
+async def name_handler(message: Message, message_input: MessageInput,
                        manager: DialogManager):
     if manager.is_preview():
         await manager.next()
@@ -49,7 +49,7 @@ async def name_handler(message: Message, dialog: DialogProtocol,
     await manager.next()
 
 
-async def other_type_handler(message: Message, dialog: DialogProtocol,
+async def other_type_handler(message: Message, message_input: MessageInput,
                              manager: DialogManager):
     await message.answer("Text is expected")
 


### PR DESCRIPTION
Fix: #199 

- Use `MessageInput` instead of `DialogProtocol` in type hints