### PR TITLE
Editing text when using the DialogManager.reset_stack() method

### DIFF
--- a/aiogram_dialog/api/protocols/manager.py
+++ b/aiogram_dialog/api/protocols/manager.py
@@ -103,8 +103,9 @@ class DialogManager(BaseDialogManager, Protocol):
         which does not require to pass manager and has only subset of methods.
         """
         raise NotImplementedError
-
-    async def reset_stack(self, remove_keyboard: bool = True) -> None:
+    
+    # Shao-mod
+    async def reset_stack(self, new_text: Optional[str], remove_keyboard: bool = True) -> None:
         """
         Reset current stack.
 

--- a/aiogram_dialog/api/protocols/manager.py
+++ b/aiogram_dialog/api/protocols/manager.py
@@ -104,8 +104,7 @@ class DialogManager(BaseDialogManager, Protocol):
         """
         raise NotImplementedError
     
-    # Shao-mod
-    async def reset_stack(self, new_text: Optional[str], remove_keyboard: bool = True) -> None:
+    async def reset_stack(self, remove_keyboard: bool = True, update_text: str = None) -> None:
         """
         Reset current stack.
 

--- a/aiogram_dialog/api/protocols/message_manager.py
+++ b/aiogram_dialog/api/protocols/message_manager.py
@@ -7,11 +7,10 @@ from aiogram_dialog.api.entities import NewMessage
 
 
 class MessageManagerProtocol(Protocol):
-    # Shao-mod
-    async def new_text(self, bot: Bot, new_text: str, old_message: Optional[Message]):
+    async def remove_kbd(self, bot: Bot, old_message: Optional[Message]):
         raise NotImplementedError
 
-    async def remove_kbd(self, bot: Bot, old_message: Optional[Message]):
+    async def update_text(self, bot: Bot, new_text: str, old_message: Optional[Message]):
         raise NotImplementedError
 
     async def show_message(

--- a/aiogram_dialog/api/protocols/message_manager.py
+++ b/aiogram_dialog/api/protocols/message_manager.py
@@ -7,6 +7,10 @@ from aiogram_dialog.api.entities import NewMessage
 
 
 class MessageManagerProtocol(Protocol):
+    # Shao-mod
+    async def new_text(self, bot: Bot, new_text: str, old_message: Optional[Message]):
+        raise NotImplementedError
+
     async def remove_kbd(self, bot: Bot, old_message: Optional[Message]):
         raise NotImplementedError
 

--- a/aiogram_dialog/manager/message_manager.py
+++ b/aiogram_dialog/manager/message_manager.py
@@ -91,6 +91,34 @@ class MessageManager(MessageManagerProtocol):
             return await self.send_message(bot, new_message)
 
         return await self.edit_message_safe(bot, new_message, old_message)
+    
+    # New text (Shao-mod)
+    async def new_text(self, bot: Bot, new_text: str, old_message: Optional[Message]):
+        if not old_message:
+            return
+        logger.debug("new_text in %s", old_message.chat)
+        try:
+            if old_message.photo:
+                await bot.edit_message_caption(
+                    chat_id=old_message.chat.id,
+                    message_id=old_message.message_id,
+                    caption=new_text,
+            )
+            else:
+                await bot.edit_message_text(
+                    chat_id=old_message.chat.id,
+                    message_id=old_message.message_id,
+                    text=new_text,
+            )
+        except TelegramBadRequest as err:
+            if "message is not modified" in err.message:
+                pass  # nothing to remove
+            elif "message can't be edited" in err.message:
+                pass
+            elif "message to edit not found" in err.message:
+                pass
+            else:
+                raise err
 
     # Clear
     async def remove_kbd(self, bot: Bot, old_message: Optional[Message]):

--- a/aiogram_dialog/manager/message_manager.py
+++ b/aiogram_dialog/manager/message_manager.py
@@ -92,33 +92,21 @@ class MessageManager(MessageManagerProtocol):
 
         return await self.edit_message_safe(bot, new_message, old_message)
     
-    # New text (Shao-mod)
-    async def new_text(self, bot: Bot, new_text: str, old_message: Optional[Message]):
+    # DialogManagar.reset_stack() -> update_text
+    async def update_text(self, bot: Bot, new_text: str, old_message: Optional[Message]):
         if not old_message:
             return
-        logger.debug("new_text in %s", old_message.chat)
-        try:
-            if old_message.photo:
-                await bot.edit_message_caption(
-                    chat_id=old_message.chat.id,
-                    message_id=old_message.message_id,
-                    caption=new_text,
-            )
-            else:
-                await bot.edit_message_text(
-                    chat_id=old_message.chat.id,
-                    message_id=old_message.message_id,
-                    text=new_text,
-            )
-        except TelegramBadRequest as err:
-            if "message is not modified" in err.message:
-                pass  # nothing to remove
-            elif "message can't be edited" in err.message:
-                pass
-            elif "message to edit not found" in err.message:
-                pass
-            else:
-                raise err
+        logger.debug("update_text in %s", old_message.chat)
+        message = Message(
+            message_id=old_message.message_id,
+            chat=old_message.chat,
+            text=new_text,
+            media=old_message.media_group_id,
+            date=old_message.date,
+            parse_mode='HTML',
+            disable_web_page_preview=True,
+        )
+        await self.edit_message_safe(bot, message, old_message)
 
     # Clear
     async def remove_kbd(self, bot: Bot, old_message: Optional[Message]):


### PR DESCRIPTION
The DialogManager method reset_stack now has a new positional argument «new_text».

It accepts a string or None:
• If new_text="some string", the message text is edited to the specified
• If new_text=None, then the message is not edited

I've tried to add a «Shao-mod» comment to each modified piece of code.