### PR TITLE
Add hide_on_single_page option to ScrollingGroup

### DIFF
--- a/aiogram_dialog/widgets/kbd/scrolling_group.py
+++ b/aiogram_dialog/widgets/kbd/scrolling_group.py
@@ -18,20 +18,32 @@ OnStateChanged = Callable[
 
 
 class ScrollingGroup(Group):
-    def __init__(self, *buttons: Keyboard, id: str, width: Optional[int] = None,
-                 height: int = 0, when: WhenCondition = None,
-                 on_page_changed: Union[OnStateChanged, WidgetEventProcessor, None] = None):
+    def __init__(
+            self,
+            *buttons: Keyboard,
+            id: str,
+            width: Optional[int] = None,
+            height: int = 0,
+            when: WhenCondition = None,
+            on_page_changed: Union[
+                OnStateChanged, WidgetEventProcessor, None,
+            ] = None,
+            hide_on_single_page: bool = False,
+    ):
         super().__init__(*buttons, id=id, width=width, when=when)
         self.height = height
         self.on_page_changed = ensure_event_processor(on_page_changed)
+        self.hide_on_single_page = hide_on_single_page
 
     async def _render_keyboard(
-            self, data: Dict, manager: DialogManager,
+            self,
+            data: Dict,
+            manager: DialogManager,
     ) -> List[List[InlineKeyboardButton]]:
         kbd = await super()._render_keyboard(data, manager)
         pages = len(kbd) // self.height + bool(len(kbd) % self.height)
         last_page = pages - 1
-        if pages == 0:
+        if pages == 0 or (pages == 1 and self.hide_on_single_page):
             return kbd
         current_page = min(last_page, self.get_page(manager))
         next_page = min(last_page, current_page + 1)


### PR DESCRIPTION
I have added the option of hide_on_single_page to the ScrollingGroup widget, this will allow for more flexibility in terms of controlling the visibility of the keyboard when there is only one page present.

The changes are the same with one in the `develop` branch 