### PR TITLE
change docs theme from sphinx_rtd_theme to furo

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'furo'
 
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,2 +1,2 @@
 sphinx
-sphinx_rtd_theme
+furo


### PR DESCRIPTION
Furo theme is prettier than sphinx_rtd_theme, supports dark and light color schemes
...and
![изображение](https://user-images.githubusercontent.com/85243265/233350776-7e6398a7-b108-410f-8d68-746a644d330a.png)
