### PR TITLE
Fixed bot answer to same message thread

### DIFF
--- a/src/aiogram_dialog/api/entities/new_message.py
+++ b/src/aiogram_dialog/api/entities/new_message.py
@@ -15,3 +15,4 @@ class NewMessage:
     show_mode: ShowMode = ShowMode.AUTO
     disable_web_page_preview: Optional[bool] = None
     media: Optional[MediaAttachment] = None
+    message_thread_id: Optional[int] = None

--- a/src/aiogram_dialog/manager/message_manager.py
+++ b/src/aiogram_dialog/manager/message_manager.py
@@ -228,6 +228,7 @@ class MessageManager(MessageManagerProtocol):
             disable_web_page_preview=new_message.disable_web_page_preview,
             reply_markup=new_message.reply_markup,
             parse_mode=new_message.parse_mode,
+            message_thread_id=new_message.message_thread_id,
         )
 
     async def send_media(self, bot: Bot, new_message: NewMessage):
@@ -247,5 +248,6 @@ class MessageManager(MessageManagerProtocol):
             caption=new_message.text,
             reply_markup=new_message.reply_markup,
             parse_mode=new_message.parse_mode,
+            message_thread_id=new_message.message_thread_id,
             **new_message.media.kwargs,
         )

--- a/src/aiogram_dialog/window.py
+++ b/src/aiogram_dialog/window.py
@@ -102,6 +102,7 @@ class Window(WindowProtocol):
             parse_mode=self.parse_mode,
             disable_web_page_preview=self.disable_web_page_preview,
             media=await self.render_media(current_data, manager),
+            message_thread_id=manager.event.message_thread_id,
         )
 
     def get_state(self) -> State:


### PR DESCRIPTION
When interacting with a bot in a group with topics, the bot responds to the topic "General", instead of the same where it should