### PR TITLE
Add BufferedInputFile to MediaAttachment

### DIFF
--- a/src/aiogram_dialog/api/entities/__init__.py
+++ b/src/aiogram_dialog/api/entities/__init__.py
@@ -2,7 +2,7 @@ __all__ = [
     "Context", "Data",
     "ChatEvent",
     "LaunchMode",
-    "MediaAttachment", "MediaId", "MediaBufferedData",
+    "MediaAttachment", "MediaBufferedData", "MediaId",
     "ShowMode", "StartMode",
     "NewMessage",
     "DEFAULT_STACK_ID", "Stack",
@@ -13,7 +13,7 @@ __all__ = [
 from .context import Context, Data
 from .events import ChatEvent
 from .launch_mode import LaunchMode
-from .media import MediaAttachment, MediaId, MediaBufferedData
+from .media import MediaAttachment, MediaBufferedData, MediaId
 from .modes import ShowMode, StartMode
 from .new_message import NewMessage
 from .stack import DEFAULT_STACK_ID, Stack

--- a/src/aiogram_dialog/api/entities/__init__.py
+++ b/src/aiogram_dialog/api/entities/__init__.py
@@ -2,7 +2,7 @@ __all__ = [
     "Context", "Data",
     "ChatEvent",
     "LaunchMode",
-    "MediaAttachment", "MediaId",
+    "MediaAttachment", "MediaId", "MediaBufferedData",
     "ShowMode", "StartMode",
     "NewMessage",
     "DEFAULT_STACK_ID", "Stack",
@@ -13,7 +13,7 @@ __all__ = [
 from .context import Context, Data
 from .events import ChatEvent
 from .launch_mode import LaunchMode
-from .media import MediaAttachment, MediaId
+from .media import MediaAttachment, MediaId, MediaBufferedData
 from .modes import ShowMode, StartMode
 from .new_message import NewMessage
 from .stack import DEFAULT_STACK_ID, Stack

--- a/src/aiogram_dialog/api/entities/media.py
+++ b/src/aiogram_dialog/api/entities/media.py
@@ -17,6 +17,12 @@ class MediaId:
         return self.file_unique_id == other.file_unique_id
 
 
+@dataclass
+class MediaBufferedData:
+    file: bytes
+    filename: str
+
+
 class MediaAttachment:
     def __init__(
             self,
@@ -24,14 +30,16 @@ class MediaAttachment:
             url: Optional[str] = None,
             path: Optional[str] = None,
             file_id: Optional[MediaId] = None,
+            data: Optional[MediaBufferedData] = None,
             use_pipe: bool = False,
             **kwargs,
     ):
-        if not (url or path or file_id):
-            raise ValueError("Neither url nor path not file_id are provided")
+        if not (url or path or file_id or data):
+            raise ValueError("Neither url nor path not file_id not data are provided")
         self.type = type
         self.url = url
         self.path = path
         self.file_id = file_id
+        self.data = data
         self.use_pipe = use_pipe
         self.kwargs = kwargs

--- a/src/aiogram_dialog/api/entities/media.py
+++ b/src/aiogram_dialog/api/entities/media.py
@@ -35,7 +35,8 @@ class MediaAttachment:
             **kwargs,
     ):
         if not (url or path or file_id or data):
-            raise ValueError("Neither url nor path not file_id not data are provided")
+            raise ValueError(
+                "Neither url nor path not file_id not data are provided")
         self.type = type
         self.url = url
         self.path = path

--- a/src/aiogram_dialog/manager/message_manager.py
+++ b/src/aiogram_dialog/manager/message_manager.py
@@ -4,9 +4,9 @@ from typing import Optional, Union
 from aiogram import Bot
 from aiogram.exceptions import TelegramBadRequest
 from aiogram.types import (
+    BufferedInputFile,
     CallbackQuery,
     ContentType,
-    BufferedInputFile,
     FSInputFile,
     InputFile,
     InputMedia,

--- a/src/aiogram_dialog/manager/message_manager.py
+++ b/src/aiogram_dialog/manager/message_manager.py
@@ -6,6 +6,7 @@ from aiogram.exceptions import TelegramBadRequest
 from aiogram.types import (
     CallbackQuery,
     ContentType,
+    BufferedInputFile,
     FSInputFile,
     InputFile,
     InputMedia,
@@ -49,8 +50,9 @@ class MessageManager(MessageManagerProtocol):
             if media.use_pipe:
                 return URLInputFile(media.url)
             return media.url
-        else:
-            return FSInputFile(media.path)
+        if media.data:
+            return BufferedInputFile(media.data.file, media.data.filename)
+        return FSInputFile(media.path)
 
     def had_media(self, old_message: Message) -> bool:
         return old_message.content_type != ContentType.TEXT


### PR DESCRIPTION
Example of use:
```python
class QRCodeMedia(Media):
    def __init__(
            self,
            *,
            data: Union[Text, str, None] = None,
            type: ContentType = ContentType.PHOTO,
            media_params: Dict = None,
            when: WhenCondition = None,
    ):
        super().__init__(when=when)
        if not data:
            raise ValueError("No data is provided")
        self.data = data
        self.type = type
        self.media_params = media_params or {}

    async def _render_media(
            self, data: Any, manager: DialogManager,
    ) -> Optional[MediaAttachment]:

        figfile = BytesIO()
        qr = QRCode(version=1, box_size=15)
        qr.add_data(self.data)
        qr.make_image().save(figfile)

        return MediaAttachment(
            type=self.type,
            data=MediaBufferedData(figfile.getvalue(), filename='qrcode'),
            **self.media_params,
        )
```
In dialog:
```python
  Window(
    Const("Scan the QRCode to go to the github page"),
    QRCodeMedia(data='https://github.com/Tishka17/aiogram_dialog'),
    state=MainSG.start,
  ),
```