### PR TITLE
Issue #277: included setup_dialogs usage description into README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ dialog = Dialog(
 
 > **Info:** All windows in a dialog MUST have states from then same `StatesGroup`
 
-After creating dialog you need to register it using `DialogRegistry`:
+After creating a dialog you need to register it into the Dispatcher and set it up using the `setup_dialogs` function:
 
 ```python
 from aiogram import Dispatcher


### PR DESCRIPTION
I've been using this framework on my own project for a while now and thought I should start contributing with it somehow.

**Overview:**
As mentioned by #277 the Dialog setup code example has changed from using the `DialogRegistry` to the `setup_dialogs` function, but the README description of that implementation was still missing the change. 

**Changes:**
- Added the `setup_dialogs` reference into the README file when setting up a new dialog