### PR TITLE
made 'items' attr identical in all widgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,5 @@
-aiogram_dialog.egg-info/
+/aiogram_dialog.egg-info/
 __pycache__
 /build
 .idea/
 /dist
-
-.venv
-.github
-__pycache__/
-.gitignore
-.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
-/aiogram_dialog.egg-info/
+aiogram_dialog.egg-info/
 __pycache__
 /build
 .idea/
 /dist
+
+.venv
+.github
+__pycache__/
+.gitignore
+.env

--- a/docs/widgets/keyboard/select/index.rst
+++ b/docs/widgets/keyboard/select/index.rst
@@ -15,8 +15,13 @@ During rendering an item text, it is passed a dictionary with:
 * ``pos0`` - position starting from 0
 
 
-So the main required thing is items. Normally it is a string with key in your window data. The value by this key must be a collection of any objects.
-If you have a static list of items you can pass it directly to a select widget instead of providing data key.
+So the main required thing is ``items``. You have 4 options to specify this parameter:
+
+* String with key in your window data (e.g. ``items="fruits"```). The value by this key must be a collection of any objects.
+* Static list of items (e.g. ``items=['apple', 'banana', 'orange']``).
+* Magic filter (e.g. ``items=F["fruits"]``). Filter has to return collection of elements.
+* Function with one parameter (``data: Dict``) that returns collection of elements (e.g. ``items=lambda d: d["fruits"]``)
+
 
 Next important thing is ids. Besides a widget id you need a function which can return id (string or integer type) for any item.
 

--- a/example/list_group.py
+++ b/example/list_group.py
@@ -9,6 +9,8 @@ from aiogram.filters.state import StatesGroup, State
 from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.types import Message
 
+from magic_filter import F
+
 from aiogram_dialog import (
     Dialog, LaunchMode, SubManager, Window, DialogManager, StartMode,
     setup_dialogs,
@@ -34,6 +36,13 @@ def when_checked(data: Dict, widget, manager: SubManager) -> bool:
     return check.is_checked()
 
 
+async def data_getter(*args, **kwargs):
+    return {
+        "fruits": ["mango", "papaya", "kiwi"],
+        "colors": ["blue", "pink"]
+    }
+
+
 dialog = Dialog(
     Window(
         Const(
@@ -52,15 +61,21 @@ dialog = Dialog(
                     id="radio",
                     item_id_getter=str,
                     items=["black", "white"],
+                    # Alternatives:
+                        #items=F["data"]["colors"],
+                        #items=lambda d: d["data"]["colors"],
                     when=when_checked,
                 )
             ),
             id="lg",
             item_id_getter=str,
             items=["apple", "orange", "pear"],
-
+            # Alternatives:
+                #items=F["fruits"],
+                #items=lambda d: d["fruits"],
         ),
         state=DialogSG.greeting,
+        getter=data_getter
     ),
     launch_mode=LaunchMode.SINGLE_TOP
 )

--- a/example/list_group.py
+++ b/example/list_group.py
@@ -8,7 +8,6 @@ from aiogram.filters import CommandStart
 from aiogram.filters.state import StatesGroup, State
 from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.types import Message
-
 from magic_filter import F
 
 from aiogram_dialog import (

--- a/example/mega/bot_dialogs/select.py
+++ b/example/mega/bot_dialogs/select.py
@@ -3,11 +3,13 @@ from typing import Any
 
 from aiogram.types import CallbackQuery
 
+from magic_filter import F
+
 from aiogram_dialog import Dialog, DialogManager, Window
 from aiogram_dialog.widgets.kbd import (
     SwitchTo, Select, Column, Radio, Multiselect,
 )
-from aiogram_dialog.widgets.text import Const, Format
+from aiogram_dialog.widgets.text import Const, Format, List
 from . import states
 from .common import MAIN_MENU_BUTTON
 
@@ -16,6 +18,7 @@ Selects_MAIN_MENU_BUTTON = SwitchTo(
 )
 
 FRUITS_KEY = "fruits"
+OTHER_KEY = "others"
 
 
 @dataclass
@@ -32,6 +35,13 @@ async def getter(**_kwargs):
             Fruit("orange_o", "Orange"),
             Fruit("pear_p", "Pear"),
         ],
+        OTHER_KEY: {
+            FRUITS_KEY: [
+                Fruit("mango_m", "Mango"),
+                Fruit("papaya_p", "Papaya"),
+                Fruit("kiwi_k", "Kiwi"),
+            ],
+        }
     }
 
 
@@ -70,11 +80,21 @@ menu_window = Window(
 )
 select_window = Window(
     Const("Select widget"),
+    List(
+        field=Format("+ {item.name} - {item.id}"),
+        items=FRUITS_KEY
+        # Alternatives:
+            #items=lambda d: d[OTHER_KEY][FRUITS_KEY],
+            #items=F[OTHER_KEY][FRUITS_KEY],
+    ),
     Column(
         Select(
             text=Format("{item.name} ({item.id})"),
             id="sel",
             items=FRUITS_KEY,
+            # Alternatives:
+                #items=lambda d: d[OTHER_KEY][FRUITS_KEY],
+                #items=F[OTHER_KEY][FRUITS_KEY],
             item_id_getter=fruit_id_getter,
             on_click=on_item_selected,
         )
@@ -91,6 +111,9 @@ radio_window = Window(
             unchecked_text=Format("⚪️ {item.name}"),
             id="radio",
             items=FRUITS_KEY,
+            # Alternatives:
+                #items=lambda d: d[OTHER_KEY][FRUITS_KEY],
+                #items=F[OTHER_KEY][FRUITS_KEY],
             item_id_getter=fruit_id_getter,
         )
     ),
@@ -107,6 +130,9 @@ multiselect_window = Window(
             unchecked_text=Format("{item.name}"),
             id="multi",
             items=FRUITS_KEY,
+            # Alternatives:
+                #items=lambda d: d[OTHER_KEY][FRUITS_KEY],
+                #items=F[OTHER_KEY][FRUITS_KEY],
             item_id_getter=fruit_id_getter,
         )
     ),

--- a/example/mega/bot_dialogs/select.py
+++ b/example/mega/bot_dialogs/select.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from typing import Any
 
 from aiogram.types import CallbackQuery
-
 from magic_filter import F
 
 from aiogram_dialog import Dialog, DialogManager, Window

--- a/src/aiogram_dialog/widgets/common/items.py
+++ b/src/aiogram_dialog/widgets/common/items.py
@@ -1,10 +1,10 @@
-from typing import Callable, Dict, Sequence, Union, TypeAlias
 from operator import itemgetter
+from typing import Callable, Dict, Sequence, Union
 
 from magic_filter import MagicFilter
 
 ItemsGetter = Callable[[Dict], Sequence]
-ItemsGetterVariant: TypeAlias = Union[str, ItemsGetter, MagicFilter, Sequence]
+ItemsGetterVariant = Union[str, ItemsGetter, MagicFilter, Sequence]
 
 
 def _get_identity(items: Sequence) -> ItemsGetter:

--- a/src/aiogram_dialog/widgets/common/items.py
+++ b/src/aiogram_dialog/widgets/common/items.py
@@ -1,0 +1,36 @@
+from typing import Callable, Dict, Sequence, Union, TypeAlias
+from operator import itemgetter
+
+from magic_filter import MagicFilter
+
+ItemsGetter = Callable[[Dict], Sequence]
+ItemsGetterVariant: TypeAlias = Union[str, ItemsGetter, MagicFilter, Sequence]
+
+
+def _get_identity(items: Sequence) -> ItemsGetter:
+    def identity(data) -> Sequence:
+        return items
+
+    return identity
+
+
+def _get_magic_getter(f: MagicFilter) -> ItemsGetter:
+    def items_magic(data: Dict) -> Sequence:
+        items = f.resolve(data)
+        if isinstance(items, Sequence):
+            return items
+        else:
+            return []
+
+    return items_magic
+
+
+def get_items_getter(attr_val: ItemsGetterVariant) -> ItemsGetter:
+    if isinstance(attr_val, str):
+        return itemgetter(attr_val)
+    elif isinstance(attr_val, MagicFilter):
+        return _get_magic_getter(attr_val)
+    elif isinstance(attr_val, Callable):
+        return attr_val
+    else:
+        return _get_identity(attr_val)

--- a/src/aiogram_dialog/widgets/kbd/list_group.py
+++ b/src/aiogram_dialog/widgets/kbd/list_group.py
@@ -2,7 +2,6 @@ from operator import itemgetter
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 from aiogram.types import CallbackQuery, InlineKeyboardButton
-
 from magic_filter import MagicFilter
 
 from aiogram_dialog.api.internal import Widget

--- a/src/aiogram_dialog/widgets/kbd/list_group.py
+++ b/src/aiogram_dialog/widgets/kbd/list_group.py
@@ -9,7 +9,7 @@ from aiogram_dialog.api.protocols import (
 from aiogram_dialog.manager.sub_manager import SubManager
 from aiogram_dialog.widgets.common import ManagedWidget, WhenCondition
 from .base import Keyboard
-from ..common.items import ItemsGetterVariant, get_items_getter
+from ..common.items import get_items_getter, ItemsGetterVariant
 
 ItemIdGetter = Callable[[Any], Union[str, int]]
 
@@ -27,7 +27,6 @@ class ListGroup(Keyboard):
         self.buttons = buttons
         self.item_id_getter = item_id_getter
         self.items_getter = get_items_getter(items)
-
 
     async def _render_keyboard(
             self, data: Dict, manager: DialogManager,

--- a/src/aiogram_dialog/widgets/kbd/select.py
+++ b/src/aiogram_dialog/widgets/kbd/select.py
@@ -14,7 +14,6 @@ from typing import (
 )
 
 from aiogram.types import CallbackQuery, InlineKeyboardButton
-
 from magic_filter import MagicFilter
 
 from aiogram_dialog.api.entities import ChatEvent

--- a/src/aiogram_dialog/widgets/kbd/select.py
+++ b/src/aiogram_dialog/widgets/kbd/select.py
@@ -22,7 +22,7 @@ from aiogram_dialog.widgets.widget_event import (
     WidgetEventProcessor,
 )
 from .base import Keyboard
-from ..common.items import ItemsGetterVariant, get_items_getter
+from ..common.items import get_items_getter, ItemsGetterVariant
 
 T = TypeVar("T")
 TypeFactory = Callable[[str], T]

--- a/src/aiogram_dialog/widgets/text/list.py
+++ b/src/aiogram_dialog/widgets/text/list.py
@@ -1,52 +1,23 @@
-from operator import itemgetter
-from typing import Callable, Dict, Sequence, Union
-
-from magic_filter import MagicFilter
+from typing import Dict
 
 from aiogram_dialog.api.protocols import DialogManager
 from aiogram_dialog.widgets.common import WhenCondition
 from .base import Text
-
-ItemsGetter = Callable[[Dict], Sequence]
-
-
-def get_identity(items: Sequence) -> ItemsGetter:
-    def identity(data) -> Sequence:
-        return items
-
-    return identity
-
-
-def get_magic_getter(f: MagicFilter) -> ItemsGetter:
-    def items_magic(data: Dict) -> Sequence:
-        items = f.resolve(data)
-        if isinstance(items, Sequence):
-            return items
-        else:
-            return []
-
-    return items_magic
+from ..common.items import ItemsGetterVariant, get_items_getter
 
 
 class List(Text):
     def __init__(
             self,
             field: Text,
-            items: Union[str, ItemsGetter, MagicFilter, Sequence],
+            items: ItemsGetterVariant,
             sep: str = "\n",
             when: WhenCondition = None,
     ):
         super().__init__(when=when)
         self.field = field
         self.sep = sep
-        if isinstance(items, str):
-            self.items_getter = itemgetter(items)
-        elif isinstance(items, MagicFilter):
-            self.items_getter = get_magic_getter(items)
-        elif isinstance(items, Callable):
-            self.items_getter = items
-        else:
-            self.items_getter = get_identity(items)
+        self.items_getter = get_items_getter(items)
 
     async def _render_text(
             self, data: Dict, manager: DialogManager,

--- a/src/aiogram_dialog/widgets/text/list.py
+++ b/src/aiogram_dialog/widgets/text/list.py
@@ -3,7 +3,7 @@ from typing import Dict
 from aiogram_dialog.api.protocols import DialogManager
 from aiogram_dialog.widgets.common import WhenCondition
 from .base import Text
-from ..common.items import ItemsGetterVariant, get_items_getter
+from ..common.items import get_items_getter, ItemsGetterVariant
 
 
 class List(Text):


### PR DESCRIPTION
Подготовил изменения по проблеме (https://t.me/aiogram_dialog/51392)

Привёл к единому виду аттрибуты 'items' у всех виджетов (List, Select, Radio, MultiSelect, ListGroup).
Теперь все эти виджеты смогут принимать лямбды и MagicFilter в качестве 'items' (в дополнение к уже имевшимся str и sequence, конечно).

В examples добаил закомментированные примеры использования. Это чисто для удобства проверки, в релиз наверное не стоит тащить.