### PR TITLE
provide support for ShowMode in SwitchTo and Cancel widgets #350

### DIFF
--- a/src/aiogram_dialog/widgets/kbd/state.py
+++ b/src/aiogram_dialog/widgets/kbd/state.py
@@ -6,8 +6,8 @@ from aiogram.types import CallbackQuery
 from aiogram_dialog.api.entities import ChatEvent, Data, ShowMode, StartMode
 from aiogram_dialog.api.protocols import DialogManager
 from aiogram_dialog.widgets.common import WhenCondition
-from aiogram_dialog.widgets.text import Const, Text
 from aiogram_dialog.widgets.kbd.button import Button, OnClick
+from aiogram_dialog.widgets.text import Const, Text
 from aiogram_dialog.widgets.widget_event import WidgetEventProcessor
 
 BACK_TEXT = Const("Back")

--- a/src/aiogram_dialog/widgets/kbd/state.py
+++ b/src/aiogram_dialog/widgets/kbd/state.py
@@ -3,12 +3,11 @@ from typing import Any, Optional
 from aiogram.fsm.state import State
 from aiogram.types import CallbackQuery
 
-from aiogram_dialog.api.entities import ChatEvent, Data, StartMode
+from aiogram_dialog.api.entities import ChatEvent, Data, StartMode, ShowMode
 from aiogram_dialog.api.protocols import DialogManager
 from aiogram_dialog.widgets.common import WhenCondition
 from aiogram_dialog.widgets.text import Const, Text
 from aiogram_dialog.widgets.widget_event import WidgetEventProcessor
-from aiogram_dialog import ShowMode
 
 from .button import Button, OnClick
 

--- a/src/aiogram_dialog/widgets/kbd/state.py
+++ b/src/aiogram_dialog/widgets/kbd/state.py
@@ -8,6 +8,8 @@ from aiogram_dialog.api.protocols import DialogManager
 from aiogram_dialog.widgets.common import WhenCondition
 from aiogram_dialog.widgets.text import Const, Text
 from aiogram_dialog.widgets.widget_event import WidgetEventProcessor
+from aiogram_dialog import ShowMode
+
 from .button import Button, OnClick
 
 BACK_TEXT = Const("Back")
@@ -41,6 +43,7 @@ class SwitchTo(EventProcessorButton):
             state: State,
             on_click: Optional[OnClick] = None,
             when: WhenCondition = None,
+            show_mode: ShowMode = None,
     ):
         super().__init__(
             text=text, on_click=self._on_click,
@@ -49,6 +52,7 @@ class SwitchTo(EventProcessorButton):
         self.text = text
         self.user_on_click = on_click
         self.state = state
+        self.show_mode = show_mode
 
     async def _on_click(
             self, callback: CallbackQuery, button: Button,
@@ -56,7 +60,7 @@ class SwitchTo(EventProcessorButton):
     ):
         if self.user_on_click:
             await self.user_on_click(callback, self, manager)
-        await manager.switch_to(self.state)
+        await manager.switch_to(self.state, show_mode=self.show_mode)
 
 
 class Next(EventProcessorButton):
@@ -117,6 +121,7 @@ class Cancel(EventProcessorButton):
             result: Any = None,
             on_click: Optional[OnClick] = None,
             when: WhenCondition = None,
+            show_mode: ShowMode = None,
     ):
         super().__init__(
             text=text, on_click=self._on_click,
@@ -125,6 +130,7 @@ class Cancel(EventProcessorButton):
         self.text = text
         self.result = result
         self.user_on_click = on_click
+        self.show_mode = show_mode
 
     async def _on_click(
             self, callback: CallbackQuery, button: Button,
@@ -132,7 +138,7 @@ class Cancel(EventProcessorButton):
     ):
         if self.user_on_click:
             await self.user_on_click(callback, self, manager)
-        await manager.done(self.result)
+        await manager.done(self.result, show_mode=self.show_mode)
 
 
 class Start(EventProcessorButton):

--- a/src/aiogram_dialog/widgets/kbd/state.py
+++ b/src/aiogram_dialog/widgets/kbd/state.py
@@ -43,7 +43,7 @@ class SwitchTo(EventProcessorButton):
             state: State,
             on_click: Optional[OnClick] = None,
             when: WhenCondition = None,
-            show_mode: ShowMode = None,
+            show_mode: ShowMode = ShowMode.AUTO,
     ):
         super().__init__(
             text=text, on_click=self._on_click,
@@ -121,7 +121,7 @@ class Cancel(EventProcessorButton):
             result: Any = None,
             on_click: Optional[OnClick] = None,
             when: WhenCondition = None,
-            show_mode: ShowMode = None,
+            show_mode: ShowMode = ShowMode.AUTO,
     ):
         super().__init__(
             text=text, on_click=self._on_click,

--- a/src/aiogram_dialog/widgets/kbd/state.py
+++ b/src/aiogram_dialog/widgets/kbd/state.py
@@ -3,13 +3,12 @@ from typing import Any, Optional
 from aiogram.fsm.state import State
 from aiogram.types import CallbackQuery
 
-from aiogram_dialog.api.entities import ChatEvent, Data, StartMode, ShowMode
+from aiogram_dialog.api.entities import ChatEvent, Data, ShowMode, StartMode
 from aiogram_dialog.api.protocols import DialogManager
 from aiogram_dialog.widgets.common import WhenCondition
 from aiogram_dialog.widgets.text import Const, Text
 from aiogram_dialog.widgets.widget_event import WidgetEventProcessor
-
-from .button import Button, OnClick
+from aiogram_dialog.widgets.kbd.button import Button, OnClick
 
 BACK_TEXT = Const("Back")
 NEXT_TEXT = Const("Next")

--- a/src/aiogram_dialog/widgets/kbd/state.py
+++ b/src/aiogram_dialog/widgets/kbd/state.py
@@ -7,8 +7,8 @@ from aiogram_dialog.api.entities import ChatEvent, Data, ShowMode, StartMode
 from aiogram_dialog.api.protocols import DialogManager
 from aiogram_dialog.widgets.common import WhenCondition
 from aiogram_dialog.widgets.text import Const, Text
-from aiogram_dialog.widgets.widget_event import WidgetEventProcessor
 from aiogram_dialog.widgets.kbd.button import Button, OnClick
+from aiogram_dialog.widgets.widget_event import WidgetEventProcessor
 
 BACK_TEXT = Const("Back")
 NEXT_TEXT = Const("Next")

--- a/src/aiogram_dialog/widgets/kbd/state.py
+++ b/src/aiogram_dialog/widgets/kbd/state.py
@@ -43,7 +43,7 @@ class SwitchTo(EventProcessorButton):
             state: State,
             on_click: Optional[OnClick] = None,
             when: WhenCondition = None,
-            show_mode: ShowMode = ShowMode.AUTO,
+            show_mode: Optional[ShowMode] = None,
     ):
         super().__init__(
             text=text, on_click=self._on_click,
@@ -121,7 +121,7 @@ class Cancel(EventProcessorButton):
             result: Any = None,
             on_click: Optional[OnClick] = None,
             when: WhenCondition = None,
-            show_mode: ShowMode = ShowMode.AUTO,
+            show_mode: Optional[ShowMode] = None,
     ):
         super().__init__(
             text=text, on_click=self._on_click,


### PR DESCRIPTION
Close issue #350, now users can pass show_mode argument to Cancel and SwitchTo widgets

```py
third_window = Window(
    "Third Window",
    Cancel(Const("Back"), show_mode=ShowMode.DELETE_AND_SEND),
    state=SecondSG.main,
)

second_dialog = Dialog(third_window)

second_window = Window(
    "Second",
    SwitchTo(Const("To first"), state=MySG.first, id="to_first"),
    state=MySG.second,
)

first_window = Window(
    "First",
    SwitchTo(Const("To second"), state=MySG.second, id="to_second", show_mode=ShowMode.SEND),
    Start(Const("To next dialog"), state=SecondSG.main, id="to_next_dialog"),
    state=MySG.first,
)
first_dialog = Dialog(first_window, second_window)
```