### PR TITLE
Remove casting to user's custom type when passing data

### DIFF
--- a/src/aiogram_dialog/widgets/kbd/select.py
+++ b/src/aiogram_dialog/widgets/kbd/select.py
@@ -120,7 +120,7 @@ class Select(Keyboard, Generic[T]):
             callback,
             self.managed(manager),
             manager,
-            self.type_factory(data),
+            data,
         )
         return True
 
@@ -181,7 +181,7 @@ class StatefulSelect(Select[T], ABC, Generic[T]):
             await self.on_item_click.process_event(
                 callback, select, manager, self.type_factory(item_id),
             )
-        await self._on_click(callback, select, manager, str(item_id))
+        await self._on_click(callback, select, manager, item_id)
 
     @abstractmethod
     async def _on_click(

--- a/src/aiogram_dialog/widgets/kbd/select.py
+++ b/src/aiogram_dialog/widgets/kbd/select.py
@@ -451,7 +451,7 @@ class Toggle(Radio[T], Generic[T]):
         if first_item is None:
             return [[]]
 
-        selected = self.get_checked(manager)
+        selected = self._get_checked(manager)
         # by default first one is shown
         if selected is None:
             pos = 0

--- a/tests/widgets/kbd/test_toggle.py
+++ b/tests/widgets/kbd/test_toggle.py
@@ -1,10 +1,17 @@
 import operator
+import enum
 
 import pytest
 from aiogram.types import TelegramObject
 
 from aiogram_dialog.widgets.kbd import Toggle
 from aiogram_dialog.widgets.text import Format
+
+
+class FruitsEnum(enum.Enum):
+    APPLE = "Apple"
+    BANANA = "Banana"
+    ORANGE = "Orange"
 
 
 @pytest.mark.asyncio
@@ -23,6 +30,31 @@ async def test_render_toggle(mock_manager) -> None:
     assert keyboard[0][0].text == "Apple"
 
     await toggle.set_checked(TelegramObject(), "2", mock_manager)
+
+    keyboard = await toggle.render_keyboard(
+        data={}, manager=mock_manager,
+    )
+
+    assert keyboard[0][0].text == "Banana"
+
+
+@pytest.mark.asyncio
+async def test_render_toggle_with_enum(mock_manager) -> None:
+    toggle = Toggle(
+        Format("{item.value}"),
+        id="fruit_enum",
+        item_id_getter=lambda item: item.name,
+        items=(FruitsEnum.APPLE, FruitsEnum.BANANA, FruitsEnum.ORANGE),
+        type_factory=lambda x: FruitsEnum[x],
+    )
+
+    keyboard = await toggle.render_keyboard(
+        data={}, manager=mock_manager,
+    )
+
+    assert keyboard[0][0].text == "Apple"
+
+    await toggle.set_checked(TelegramObject(), FruitsEnum.BANANA.name, mock_manager)
 
     keyboard = await toggle.render_keyboard(
         data={}, manager=mock_manager,


### PR DESCRIPTION
This commit is aimed to fix issue with doublecasting when sequence of enum members is passed as items of Select-like widgets