### PR TITLE
fix: NumberedPager._render_keyboard 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@ __pycache__
 /build
 .idea/
 /dist
-.venv/
-.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 .idea/
 /dist
 .venv/
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 /build
 .idea/
 /dist
+.venv/

--- a/src/aiogram_dialog/widgets/kbd/pager.py
+++ b/src/aiogram_dialog/widgets/kbd/pager.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from enum import Enum
-from typing import TypedDict, Union
+from typing import TypedDict, Optional, Union
 
 from aiogram.types import CallbackQuery, InlineKeyboardButton
 
@@ -224,7 +224,7 @@ class NumberedPager(BasePager):
             page_text: Text = DEFAULT_PAGE_TEXT,
             current_page_text: Text = DEFAULT_CURRENT_PAGE_TEXT,
             when: WhenCondition = None,
-            length: int | None = None,
+            length: Optional[int] = None,
     ):
         super().__init__(id=id, scroll=scroll, when=when)
         self.page_text = page_text

--- a/src/aiogram_dialog/widgets/kbd/pager.py
+++ b/src/aiogram_dialog/widgets/kbd/pager.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from enum import Enum
-from typing import TypedDict, Optional, Union
+from typing import Optional, TypedDict, Union
 
 from aiogram.types import CallbackQuery, InlineKeyboardButton
 

--- a/src/aiogram_dialog/widgets/kbd/pager.py
+++ b/src/aiogram_dialog/widgets/kbd/pager.py
@@ -268,27 +268,6 @@ class NumberedPager(BasePager):
         buttons = []
         pages = data["pages"]
         current_page = data["current_page"]
-        for target_page in range(pages):
-            button_data = await self._prepare_page_data(
-                data=data, target_page=target_page,
-            )
-            if target_page == current_page:
-                text_widget = self.current_page_text
-            else:
-                text_widget = self.page_text
-            text = await text_widget.render_text(button_data, manager)
-            buttons.append(InlineKeyboardButton(
-                text=text,
-                callback_data=self._item_callback_data(target_page),
-            ))
-        return [buttons]
-
-    async def _render_keyboard(
-            self, data: PagerData, manager: DialogManager,
-    ) -> RawKeyboard:
-        buttons = []
-        pages = data["pages"]
-        current_page = data["current_page"]
         final_buttons = []
         for target_page in range(pages):
             if len(buttons) >= DEFAULT_PAGER_ROW_LENGTH:

--- a/src/aiogram_dialog/widgets/kbd/pager.py
+++ b/src/aiogram_dialog/widgets/kbd/pager.py
@@ -272,7 +272,7 @@ class NumberedPager(BasePager):
         final_buttons = []
         for target_page in range(pages):
             if self.length is not None and len(buttons) >= self.length:
-                final_buttons.append(buttons[:])
+                final_buttons.append(buttons)
                 buttons = []
             button_data = await self._prepare_page_data(
                 data=data, target_page=target_page,

--- a/src/aiogram_dialog/widgets/kbd/pager.py
+++ b/src/aiogram_dialog/widgets/kbd/pager.py
@@ -42,8 +42,6 @@ DEFAULT_CURRENT_BUTTON_TEXT = Format("{current_page1}")
 DEFAULT_PAGE_TEXT = Format("{target_page1}")
 DEFAULT_CURRENT_PAGE_TEXT = Format("[ {current_page1} ]")
 
-DEFAULT_PAGER_ROW_LENGTH = 8
-
 
 class BasePager(Keyboard, ABC):
     def __init__(
@@ -225,8 +223,8 @@ class NumberedPager(BasePager):
             id: str = DEFAULT_PAGER_ID,
             page_text: Text = DEFAULT_PAGE_TEXT,
             current_page_text: Text = DEFAULT_CURRENT_PAGE_TEXT,
-            length: int = DEFAULT_PAGER_ROW_LENGTH,
             when: WhenCondition = None,
+            length: int | None = None,
     ):
         super().__init__(id=id, scroll=scroll, when=when)
         self.page_text = page_text
@@ -273,7 +271,7 @@ class NumberedPager(BasePager):
         current_page = data["current_page"]
         final_buttons = []
         for target_page in range(pages):
-            if len(buttons) >= self.length:
+            if self.length is not None and len(buttons) >= self.length:
                 final_buttons.append(buttons[:])
                 buttons = []
             button_data = await self._prepare_page_data(

--- a/src/aiogram_dialog/widgets/kbd/pager.py
+++ b/src/aiogram_dialog/widgets/kbd/pager.py
@@ -44,6 +44,7 @@ DEFAULT_CURRENT_PAGE_TEXT = Format("[ {current_page1} ]")
 
 DEFAULT_PAGER_ROW_LENGTH = 8
 
+
 class BasePager(Keyboard, ABC):
     def __init__(
             self,

--- a/src/aiogram_dialog/widgets/kbd/pager.py
+++ b/src/aiogram_dialog/widgets/kbd/pager.py
@@ -225,11 +225,13 @@ class NumberedPager(BasePager):
             id: str = DEFAULT_PAGER_ID,
             page_text: Text = DEFAULT_PAGE_TEXT,
             current_page_text: Text = DEFAULT_CURRENT_PAGE_TEXT,
+            length: int = DEFAULT_PAGER_ROW_LENGTH,
             when: WhenCondition = None,
     ):
         super().__init__(id=id, scroll=scroll, when=when)
         self.page_text = page_text
         self.current_page_text = current_page_text
+        self.length = length
 
     async def _prepare_data(
             self, data: dict,
@@ -271,7 +273,7 @@ class NumberedPager(BasePager):
         current_page = data["current_page"]
         final_buttons = []
         for target_page in range(pages):
-            if len(buttons) >= DEFAULT_PAGER_ROW_LENGTH:
+            if len(buttons) >= self.length:
                 final_buttons.append(buttons[:])
                 buttons = []
             button_data = await self._prepare_page_data(


### PR DESCRIPTION
The number of buttons was limited by the telegram limit and only 8 were displayed. Added a transfer to the next list to create several rows with buttons

Before:
![Screenshot from 2025-03-06 12-53-32](https://github.com/user-attachments/assets/092f93a5-3629-4b2b-92dd-554b3b12e2b3)
After:
![Screenshot from 2025-03-06 12-53-13](https://github.com/user-attachments/assets/8690322a-ed8a-4a79-9cc0-5286102e6d6a)
 