### PR TITLE
Fix build errors due to missing `sphinx.configuration`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,6 +3,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+sphinx:
+  configuration: docs/conf.py
 python:
   install:
     - method: pip


### PR DESCRIPTION
Fixes build errors due to missing `sphinx.configuration`
https://app.readthedocs.org/projects/aiogram-dialog/builds/28760176/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation build configuration to explicitly specify the Sphinx configuration file location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->