### PR TITLE
feat: validate unique StatesGroup per dialog and consistent states per window

### DIFF
--- a/src/aiogram_dialog/setup.py
+++ b/src/aiogram_dialog/setup.py
@@ -75,8 +75,17 @@ class DialogRegistry(DialogRegistryProtocol):
         return self._states_groups
 
     def refresh(self):
-        dialogs = collect_dialogs(self.router)
-        self._dialogs = {d.states_group(): d for d in dialogs}
+        for dialog in collect_dialogs(self.router):
+            states_group = dialog.states_group()
+            if states_group in self._dialogs:
+                existing_dialog = self._dialogs[states_group]
+                raise ValueError(
+                    f"StatesGroup '{states_group.__name__}' "
+                    f"is used in multiple dialogs: "
+                    f"'{existing_dialog}' and '{dialog}'",
+                )
+            self._dialogs[states_group] = dialog
+
         self._states_groups = {
             d.states_group_name(): d.states_group()
             for d in self._dialogs.values()

--- a/tests/test_dialog_state_validation.py
+++ b/tests/test_dialog_state_validation.py
@@ -1,0 +1,50 @@
+# tests for https://github.com/Tishka17/aiogram_dialog/issues/493
+
+import pytest
+from aiogram import Dispatcher
+from aiogram.fsm.state import State, StatesGroup
+
+from aiogram_dialog import Dialog, Window, setup_dialogs
+from aiogram_dialog.widgets.text import Const
+
+
+class First(StatesGroup):
+    state = State()
+
+
+class Second(StatesGroup):
+    state = State()
+
+
+@pytest.mark.asyncio
+async def test_one_state_group_per_dialog() -> None:
+    first_dialog = Dialog(Window(Const("foo"), state=First.state))
+    second_dialog = Dialog(Window(Const("bar"), state=First.state))
+    dp = Dispatcher()
+    dp.include_routers(first_dialog, second_dialog)
+
+    setup_dialogs(dp)
+    with pytest.raises(
+        ValueError,
+        match=r"StatesGroup '.+' is used in multiple dialogs: '.+' and '.+'",
+    ):
+        await dp.emit_startup()
+
+
+def test_one_state_per_window() -> None:
+    first_window = Window(Const("foo"), state=First.state)
+    seconds_window = Window(Const("bar"), state=First.state)
+
+    with pytest.raises(ValueError, match="Multiple windows with state"):
+        Dialog(first_window, seconds_window)
+
+
+def test_one_state_group_in_one_dialog() -> None:
+    first_window = Window(Const("foo"), state=First.state)
+    seconds_window = Window(Const("bar"), state=Second.state)
+
+    with pytest.raises(
+        ValueError,
+        match="All windows must be attached to same StatesGroup",
+    ):
+        Dialog(first_window, seconds_window)


### PR DESCRIPTION
Add validation for unique `StatesGroup` usage during `Dispatcher.emit_startup` and corresponding tests for https://github.com/Tishka17/aiogram_dialog/issues/493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to prevent multiple dialogs from using the same state group, providing clear error messages if duplicates are detected.

* **Tests**
  * Added tests to validate dialog state management, ensuring that dialogs and windows have unique state groups and states, and that configuration errors are properly reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->