### PR TITLE
feat: add support for protect_content

### DIFF
--- a/src/aiogram_dialog/api/entities/new_message.py
+++ b/src/aiogram_dialog/api/entities/new_message.py
@@ -30,6 +30,7 @@ class OldMessage:
     media_id: Optional[str]
     media_uniq_id: Optional[str]
     text: Union[str, None, UnknownText] = None
+    has_protected_content: Optional[bool] = None
     has_reply_keyboard: bool = False
     business_connection_id: Optional[str] = None
     content_type: Optional[ContentType] = None
@@ -43,6 +44,7 @@ class NewMessage:
     text: Optional[str] = None
     reply_markup: Optional[MarkupVariant] = None
     parse_mode: Optional[str] = None
+    protect_content: Optional[bool] = None
     show_mode: ShowMode = ShowMode.AUTO
     media: Optional[MediaAttachment] = None
     link_preview_options: Optional[LinkPreviewOptions] = None

--- a/src/aiogram_dialog/api/entities/stack.py
+++ b/src/aiogram_dialog/api/entities/stack.py
@@ -50,6 +50,7 @@ class Stack:
     )
     content_type: Optional[ContentType] = field(compare=False, default=None)
     access_settings: Optional[AccessSettings] = None
+    has_protected_content: Optional[bool] = field(compare=False, default=None)
 
     @property
     def id(self):

--- a/src/aiogram_dialog/manager/manager.py
+++ b/src/aiogram_dialog/manager/manager.py
@@ -441,6 +441,7 @@ class ManagerImpl(DialogManager):
                 media_id=(media_id.file_id if media_id else None),
                 media_uniq_id=(media_id.file_unique_id if media_id else None),
                 text=current_message.text,
+                has_protected_content=current_message.has_protected_content,
                 has_reply_keyboard=self.is_event_simulated(),
                 chat=event_context.chat,
                 message_id=current_message.message_id,
@@ -454,6 +455,7 @@ class ManagerImpl(DialogManager):
                 media_id=None,
                 media_uniq_id=None,
                 text=UnknownText.UNKNOWN,
+                has_protected_content=stack.has_protected_content,
                 has_reply_keyboard=self.is_event_simulated(),
                 chat=event_context.chat,
                 message_id=stack.last_message_id,
@@ -479,6 +481,7 @@ class ManagerImpl(DialogManager):
             media_id=stack.last_media_id,
             media_uniq_id=stack.last_media_unique_id,
             text=UnknownText.UNKNOWN,
+            has_protected_content=stack.has_protected_content,
             has_reply_keyboard=stack.last_reply_keyboard,
             chat=event_context.chat,
             message_id=stack.last_message_id,
@@ -493,6 +496,7 @@ class ManagerImpl(DialogManager):
         stack.last_media_unique_id = message.media_uniq_id
         stack.last_reply_keyboard = message.has_reply_keyboard
         stack.content_type = message.content_type
+        stack.has_protected_content = message.has_protected_content
 
     def _calc_show_mode(self) -> ShowMode:  # noqa: PLR0911
         if self.show_mode is not ShowMode.AUTO:

--- a/src/aiogram_dialog/manager/message_manager.py
+++ b/src/aiogram_dialog/manager/message_manager.py
@@ -64,6 +64,7 @@ def _combine(sent_message: NewMessage, message_result: Message) -> OldMessage:
     return OldMessage(
         message_id=message_result.message_id,
         chat=message_result.chat,
+        has_protected_content=message_result.has_protected_content,
         has_reply_keyboard=isinstance(
             sent_message.reply_markup, ReplyKeyboardMarkup,
         ),
@@ -134,7 +135,11 @@ class MessageManager(MessageManagerProtocol):
             # we cannot actually compare reply keyboards
             (new_message.reply_markup or old_message.has_reply_keyboard) or
             # we do not know if link preview changed
-            new_message.link_preview_options
+            new_message.link_preview_options or
+            (
+                bool(new_message.protect_content)
+                != bool(old_message.has_protected_content)
+            )
         ):
             return True
 
@@ -317,6 +322,11 @@ class MessageManager(MessageManagerProtocol):
     async def edit_message(
             self, bot: Bot, new_message: NewMessage, old_message: OldMessage,
     ) -> Message:
+        if bool(old_message.has_protected_content) != \
+           bool(new_message.protect_content):
+            await self.remove_message_safe(bot, old_message, new_message)
+            return await self.send_message(bot, new_message)
+
         if new_message.media:
             if (
                 old_message.media_id is not None and
@@ -396,6 +406,7 @@ class MessageManager(MessageManagerProtocol):
             business_connection_id=new_message.business_connection_id,
             reply_markup=new_message.reply_markup,
             parse_mode=new_message.parse_mode,
+            protect_content=new_message.protect_content,
             link_preview_options=new_message.link_preview_options,
         )
 
@@ -418,5 +429,6 @@ class MessageManager(MessageManagerProtocol):
             caption=new_message.text,
             reply_markup=new_message.reply_markup,
             parse_mode=new_message.parse_mode,
+            protect_content=new_message.protect_content,
             **new_message.media.kwargs,
         )

--- a/src/aiogram_dialog/window.py
+++ b/src/aiogram_dialog/window.py
@@ -49,6 +49,7 @@ class Window(WindowProtocol):
             markup_factory: MarkupFactory = _DEFAULT_MARKUP_FACTORY,
             parse_mode: Optional[str] = UNSET_PARSE_MODE,
             disable_web_page_preview: Optional[bool] = None,
+            protect_content: Optional[bool] = None,
             preview_add_transitions: Optional[list[Keyboard]] = None,
             preview_data: GetterVariant = None,
     ):
@@ -67,6 +68,7 @@ class Window(WindowProtocol):
         self.on_process_result = on_process_result
         self.markup_factory = markup_factory
         self.parse_mode = parse_mode
+        self.protect_content = protect_content
         self.preview_add_transitions = preview_add_transitions
         if disable_web_page_preview is not None:
             if self.link_preview:
@@ -165,6 +167,7 @@ class Window(WindowProtocol):
                 text=await self.render_text(current_data, manager),
                 reply_markup=await self.render_kbd(current_data, manager),
                 parse_mode=self.parse_mode,
+                protect_content=self.protect_content,
                 media=await self.render_media(current_data, manager),
                 link_preview_options=await self.render_link_preview(
                     current_data, manager,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Telegram protected content on messages.
  * New option to set protect_content on windows; applied when sending text and media.
  * Stored message metadata now tracks whether content was protected.

* **Bug Fixes**
  * Editing respects protected content: when protection changes the message is re-sent instead of edited, preventing invalid edits (may produce a new message ID).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->