### PR TITLE
Add `FgManager` with waiting for update to complete

### DIFF
--- a/src/aiogram_dialog/manager/bg_manager.py
+++ b/src/aiogram_dialog/manager/bg_manager.py
@@ -27,7 +27,7 @@ from aiogram_dialog.api.protocols import (
     BgManagerFactory,
     UnsetId,
 )
-from aiogram_dialog.manager.updater import Updater
+from aiogram_dialog.manager.bg_updater import BgUpdater
 from aiogram_dialog.utils import is_chat_loaded, is_user_loaded
 
 logger = getLogger(__name__)
@@ -86,7 +86,7 @@ class BgManager(BaseDialogManager):
             business_connection_id=business_connection_id,
         )
         self._router = router
-        self._updater = Updater(router)
+        self._updater = BgUpdater(router)
         self.intent_id = intent_id
         self.stack_id = stack_id
         self.load = load

--- a/src/aiogram_dialog/manager/bg_updater.py
+++ b/src/aiogram_dialog/manager/bg_updater.py
@@ -1,0 +1,17 @@
+import asyncio
+from contextvars import copy_context
+
+from aiogram import Bot
+
+from aiogram_dialog.api.entities import DialogUpdate
+from aiogram_dialog.manager.updater import Updater
+
+
+class BgUpdater(Updater):
+    async def notify(self, bot: Bot, update: DialogUpdate) -> None:
+        def callback():
+            asyncio.create_task(  # noqa: RUF006
+                self._process_update(bot, update),
+            )
+
+        asyncio.get_running_loop().call_soon(callback, context=copy_context())

--- a/src/aiogram_dialog/manager/fg_manager.py
+++ b/src/aiogram_dialog/manager/fg_manager.py
@@ -1,0 +1,288 @@
+from logging import getLogger
+from typing import Any, Optional, Union
+
+from aiogram import Bot, Router
+from aiogram.fsm.state import State
+from aiogram.types import Chat, User
+
+from aiogram_dialog.api.entities import (
+    DEFAULT_STACK_ID,
+    AccessSettings,
+    Data,
+    DialogAction,
+    DialogStartEvent,
+    DialogSwitchEvent,
+    DialogUpdate,
+    DialogUpdateEvent,
+    EventContext,
+    ShowMode,
+    StartMode,
+)
+from aiogram_dialog.api.internal import (
+    FakeChat,
+    FakeUser,
+)
+from aiogram_dialog.api.protocols import (
+    BaseDialogManager,
+    BgManagerFactory,
+    UnsetId,
+)
+from aiogram_dialog.manager.simple_updater import SimpleUpdater
+from aiogram_dialog.utils import is_chat_loaded, is_user_loaded
+
+logger = getLogger(__name__)
+
+
+def coalesce_business_connection_id(
+    *,
+    user: User,
+    chat: Chat,
+    business_connection_id: Union[str, None, UnsetId],
+    event_context: EventContext,
+) -> Optional[str]:
+    if business_connection_id is not UnsetId.UNSET:
+        return business_connection_id
+    if user.id != event_context.user.id:
+        return None
+    if chat.id != event_context.chat.id:
+        return None
+    return event_context.business_connection_id
+
+
+def coalesce_thread_id(
+    *,
+    user: User,
+    chat: Chat,
+    thread_id: Union[str, None, UnsetId],
+    event_context: EventContext,
+) -> Optional[str]:
+    if thread_id is not UnsetId.UNSET:
+        return thread_id
+    if user.id != event_context.user.id:
+        return None
+    if chat.id != event_context.chat.id:
+        return None
+    return None
+
+
+class FgManager(BaseDialogManager):
+    def __init__(
+        self,
+        user: User,
+        chat: Chat,
+        bot: Bot,
+        router: Router,
+        intent_id: Optional[str],
+        stack_id: Optional[str],
+        thread_id: Optional[int] = None,
+        business_connection_id: Optional[str] = None,
+        load: bool = False,
+    ):
+        self._event_context = EventContext(
+            chat=chat,
+            user=user,
+            bot=bot,
+            thread_id=thread_id,
+            business_connection_id=business_connection_id,
+        )
+        self._router = router
+        self._updater = SimpleUpdater(router)
+        self.intent_id = intent_id
+        self.stack_id = stack_id
+        self.load = load
+
+    def _get_fake_user(self, user_id: Optional[int] = None) -> User:
+        """Get User if we have info about him or FakeUser instead."""
+        if user_id in (None, self._event_context.user.id):
+            return self._event_context.user
+        return FakeUser(id=user_id, is_bot=False, first_name="")
+
+    def _get_fake_chat(self, chat_id: Optional[int] = None) -> Chat:
+        """Get Chat if we have info about him or FakeChat instead."""
+        if chat_id in (None, self._event_context.chat.id):
+            return self._event_context.chat
+        return FakeChat(id=chat_id, type="")
+
+    def bg(
+        self,
+        user_id: Optional[int] = None,
+        chat_id: Optional[int] = None,
+        stack_id: Optional[str] = None,
+        thread_id: Union[int, None, UnsetId] = UnsetId.UNSET,
+        business_connection_id: Union[str, None, UnsetId] = UnsetId.UNSET,
+        load: bool = False,
+    ) -> "BaseDialogManager":
+        chat = self._get_fake_chat(chat_id)
+        user = self._get_fake_user(user_id)
+
+        new_event_context = EventContext(
+            bot=self._event_context.bot,
+            chat=chat,
+            user=user,
+            thread_id=coalesce_thread_id(
+                chat=chat,
+                user=user,
+                thread_id=thread_id,
+                event_context=self._event_context,
+            ),
+            business_connection_id=coalesce_business_connection_id(
+                chat=chat,
+                user=user,
+                business_connection_id=business_connection_id,
+                event_context=self._event_context,
+            ),
+        )
+        if stack_id is None:
+            if self._event_context == new_event_context:
+                stack_id = self.stack_id
+                intent_id = self.intent_id
+            else:
+                stack_id = DEFAULT_STACK_ID
+                intent_id = None
+        else:
+            intent_id = None
+
+        return FgManager(
+            user=new_event_context.user,
+            chat=new_event_context.chat,
+            bot=new_event_context.bot,
+            router=self._router,
+            intent_id=intent_id,
+            stack_id=stack_id,
+            thread_id=new_event_context.thread_id,
+            business_connection_id=new_event_context.business_connection_id,
+            load=load,
+        )
+
+    def _base_event_params(self):
+        return {
+            "from_user": self._event_context.user,
+            "chat": self._event_context.chat,
+            "intent_id": self.intent_id,
+            "stack_id": self.stack_id,
+            "thread_id": self._event_context.thread_id,
+            "business_connection_id":
+                self._event_context.business_connection_id,
+        }
+
+    async def _notify(self, event: DialogUpdateEvent):
+        bot = self._event_context.bot
+        update = DialogUpdate(aiogd_update=event.as_(bot)).as_(bot)
+        return await self._updater.notify(bot=bot, update=update)
+
+    async def _load(self):
+        if self.load:
+            bot = self._event_context.bot
+            if not is_chat_loaded(self._event_context.chat):
+                logger.debug(
+                    "load chat: %s", self._event_context.chat.id,
+                )
+                self._event_context.chat = await bot.get_chat(
+                    self._event_context.chat.id,
+                )
+            if not is_user_loaded(self._event_context.user):
+                logger.debug(
+                    "load user %s from chat %s",
+                    self._event_context.chat.id, self._event_context.user.id,
+                )
+                chat_member = await bot.get_chat_member(
+                    self._event_context.chat.id, self._event_context.user.id,
+                )
+                self._event_context.user = chat_member.user
+
+    async def done(
+        self,
+        result: Any = None,
+        show_mode: Optional[ShowMode] = None,
+    ) -> None:
+        await self._load()
+        return await self._notify(
+            DialogUpdateEvent(
+                action=DialogAction.DONE,
+                data=result,
+                show_mode=show_mode,
+                **self._base_event_params(),
+            ),
+        )
+
+    async def start(
+        self,
+        state: State,
+        data: Data = None,
+        mode: StartMode = StartMode.NORMAL,
+        show_mode: Optional[ShowMode] = None,
+        access_settings: Optional[AccessSettings] = None,
+    ) -> None:
+        await self._load()
+        return await self._notify(
+            DialogStartEvent(
+                action=DialogAction.START,
+                data=data,
+                new_state=state,
+                mode=mode,
+                show_mode=show_mode,
+                access_settings=access_settings,
+                **self._base_event_params(),
+            ),
+        )
+
+    async def switch_to(
+        self,
+        state: State,
+        show_mode: Optional[ShowMode] = None,
+    ) -> None:
+        await self._load()
+        return await self._notify(
+            DialogSwitchEvent(
+                action=DialogAction.SWITCH,
+                data={},
+                new_state=state,
+                show_mode=show_mode,
+                **self._base_event_params(),
+            ),
+        )
+
+    async def update(
+        self,
+        data: dict,
+        show_mode: Optional[ShowMode] = None,
+    ) -> None:
+        await self._load()
+        return await self._notify(
+            DialogUpdateEvent(
+                action=DialogAction.UPDATE, data=data, show_mode=show_mode,
+                **self._base_event_params(),
+            ),
+        )
+
+
+class FgManagerFactoryImpl(BgManagerFactory):
+    def __init__(self, router: Router):
+        self._router = router
+
+    def bg(
+        self,
+        bot: Bot,
+        user_id: int,
+        chat_id: int,
+        stack_id: Optional[str] = None,
+        thread_id: Optional[int] = None,
+        business_connection_id: Optional[str] = None,
+        load: bool = False,
+    ) -> "BaseDialogManager":
+        chat = FakeChat(id=chat_id, type="")
+        user = FakeUser(id=user_id, is_bot=False, first_name="")
+        if stack_id is None:
+            stack_id = DEFAULT_STACK_ID
+
+        return FgManager(
+            user=user,
+            chat=chat,
+            bot=bot,
+            router=self._router,
+            intent_id=None,
+            stack_id=stack_id,
+            thread_id=thread_id,
+            business_connection_id=business_connection_id,
+            load=load,
+        )

--- a/src/aiogram_dialog/manager/simple_updater.py
+++ b/src/aiogram_dialog/manager/simple_updater.py
@@ -1,0 +1,13 @@
+from contextvars import copy_context
+from typing import Any
+
+from aiogram import Bot
+
+from aiogram_dialog.api.entities import DialogUpdate
+from aiogram_dialog.manager.updater import Updater
+
+
+class SimpleUpdater(Updater):
+    async def notify(self, bot: Bot, update: DialogUpdate) -> Any:
+        context = copy_context()
+        return await context.run(self._process_update, bot, update)

--- a/src/aiogram_dialog/manager/updater.py
+++ b/src/aiogram_dialog/manager/updater.py
@@ -1,12 +1,12 @@
-import asyncio
-from contextvars import copy_context
+from abc import ABC, abstractmethod
+from typing import Any
 
 from aiogram import Bot, Dispatcher, Router
 
 from aiogram_dialog.api.entities import DialogUpdate
 
 
-class Updater:
+class Updater(ABC):
     def __init__(self, dp: Router):
         while dp.parent_router:
             dp = dp.parent_router
@@ -14,17 +14,13 @@ class Updater:
             raise TypeError("Root router must be Dispatcher.")
         self.dp = dp
 
-    async def notify(self, bot: Bot, update: DialogUpdate) -> None:
-        def callback():
-            asyncio.create_task(  # noqa: RUF006
-                self._process_update(bot, update),
-            )
+    @abstractmethod
+    async def notify(self, bot: Bot, update: DialogUpdate) -> Any:
+        pass
 
-        asyncio.get_running_loop().call_soon(callback, context=copy_context())
-
-    async def _process_update(self, bot: Bot, update: DialogUpdate) -> None:
+    async def _process_update(self, bot: Bot, update: DialogUpdate) -> Any:
         event = update.event
-        await self.dp.propagate_event(
+        return await self.dp.propagate_event(
             update_type="update",
             event=update,
             bot=bot,

--- a/src/aiogram_dialog/setup.py
+++ b/src/aiogram_dialog/setup.py
@@ -226,6 +226,7 @@ def setup_dialogs(
         media_id_storage: Optional[MediaIdStorageProtocol] = None,
         stack_access_validator: Optional[StackAccessValidator] = None,
         events_isolation: Optional[BaseEventIsolation] = None,
+        bg_manager_factory: Optional[BgManagerFactory] = None,
 ) -> BgManagerFactory:
     _setup_event_observer(router)
     _register_event_handler(router, handle_update)
@@ -240,7 +241,8 @@ def setup_dialogs(
         stack_access_validator,
     )
     events_isolation = _prepare_events_isolation(events_isolation)
-    bg_manager_factory = BgManagerFactoryImpl(router)
+    if bg_manager_factory is None:
+        bg_manager_factory = BgManagerFactoryImpl(router)
     _register_middleware(
         router=router,
         dialog_manager_factory=dialog_manager_factory,

--- a/tests/test_bg_managers.py
+++ b/tests/test_bg_managers.py
@@ -1,0 +1,46 @@
+import asyncio
+
+import pytest
+from aiogram import Dispatcher
+from aiogram.fsm.state import State, StatesGroup
+
+from aiogram_dialog import Dialog, Window, setup_dialogs
+from aiogram_dialog.manager.fg_manager import FgManagerFactoryImpl
+from aiogram_dialog.test_tools.bot_client import FakeBot
+from aiogram_dialog.widgets.text import Const
+
+
+class SomeStates(StatesGroup):
+    some = State()
+
+some_dialog = Dialog(Window(Const("Text"), state=SomeStates.some))
+
+
+@pytest.mark.asyncio
+async def test_bg_manager_running_without_waiting() -> None:
+    bot = FakeBot()
+    dp = Dispatcher()
+    dp.include_routers(some_dialog)
+    bg_manager_factory = setup_dialogs(dp)
+    bg_manager = bg_manager_factory.bg(bot=bot, user_id=1, chat_id=1)
+
+    # No RuntimeError, because BgManager schedules the dialog start in the background
+    # and does not await it
+    await bg_manager.start(state=SomeStates.some)
+
+
+@pytest.mark.asyncio
+async def test_fg_manager_running_with_waiting() -> None:
+    bot = FakeBot()
+    dp = Dispatcher()
+    dp.include_routers(some_dialog)
+    bg_manager_factory = setup_dialogs(dp, bg_manager_factory=FgManagerFactoryImpl(dp))
+    bg_manager = bg_manager_factory.bg(bot=bot, user_id=1, chat_id=1)
+
+    # Raises RuntimeError, because FgManager awaits the dialog start,
+    # triggering a FakeBot Telegram API call.
+    with pytest.raises(
+        RuntimeError,
+        match="Fake bot should not be used to call telegram",
+    ):
+        await bg_manager.start(state=SomeStates.some)


### PR DESCRIPTION
# Description

This PR introduces `FgManager`, a new dialog manager that processes dialog updates and returns their results using `return await self._updater.notify(...)`. Unlike `BgManager`, which schedules updates in the background via an asyncio task (using `asyncio.get_running_loop().call_soon(...)`), `FgManager` waits for the update to complete, allowing it to be used in cases where you need to wait for the update to complete.

# Changes

1. **Refactored `Updater` into an abstract base class** with two implementations:
   - `BgUpdater`: Schedules updates in the background, used by `BgManager`.
   - `SimpleUpdater`: Waiting for update to complete, used by `FgManager`.  
2. **Added `FgManager` and `FgManagerFactory`** by duplicating `BgManager` and `BgManagerFactory`, modifying `FgManager` to return the result of `await self._updater.notify(...)` for synchronous behavior.  
3. **Enhanced `setup_dialogs`** to accept an optional `bg_manager_factory` parameter, defaulting to `BgManagerFactoryImpl` if none is provided, allowing custom manager implementations (e.g., `FgManagerFactoryImpl`).  
4. **Added tests** to demonstrate the behavioral difference:
   - `test_bg_manager_starts_dialog_without_waiting`: Verifies `BgManager` schedules dialog starts in the background without raising a `RuntimeError`.
   - `test_fg_manager_awaits_dialog_start_with_error`: Confirms `FgManager` awaits dialog starts, raising a `RuntimeError` with `FakeBot` due to its Telegram API call limitation.

# Feedback Request

To implement `FgManager`, I duplicated `BgManager` and `BgManagerFactory`, modifying methods to return the awaited result. This works but introduces code duplication. Could you suggest a better way to share code between `BgManager` and `FgManager`?