### PR TITLE
Fix: Add `.as_(bot)` to `ReplyCallbackQuery.message` for fake callbacks

### DIFF
--- a/src/aiogram_dialog/context/intent_middleware.py
+++ b/src/aiogram_dialog/context/intent_middleware.py
@@ -2,7 +2,7 @@ from collections.abc import Awaitable, Callable
 from logging import getLogger
 from typing import Any
 
-from aiogram import Router
+from aiogram import Bot, Router
 from aiogram.dispatcher.event.bases import UNHANDLED
 from aiogram.dispatcher.middlewares.base import BaseMiddleware
 from aiogram.fsm.storage.base import BaseEventIsolation, BaseStorage
@@ -306,6 +306,7 @@ class IntentMiddlewareFactory:
 
         _, callback_data = split_reply_callback(event.text)
         if callback_data:
+            bot: Bot = data["bot"]
             query = ReplyCallbackQuery(
                 id="",
                 message=InaccessibleBusinessMessage(
@@ -314,13 +315,13 @@ class IntentMiddlewareFactory:
                     business_connection_id=event.business_connection_id,
                     message_thread_id=event.message_thread_id,
                     is_topic_message=event.is_topic_message,
-                ),
+                ).as_(bot),
                 original_message=event,
                 data=callback_data,
                 from_user=event.from_user,
                 # we cannot know real chat instance
                 chat_instance=str(event.chat.id),
-            ).as_(data["bot"])
+            ).as_(bot)
             router: Router = data["event_router"]
             return await router.propagate_event(
                 "callback_query",

--- a/src/aiogram_dialog/test_tools/mock_message_manager.py
+++ b/src/aiogram_dialog/test_tools/mock_message_manager.py
@@ -7,6 +7,7 @@ from aiogram.types import (
     Audio,
     CallbackQuery,
     Document,
+    InlineKeyboardMarkup,
     Message,
     PhotoSize,
     ReplyKeyboardMarkup,
@@ -59,6 +60,9 @@ class MockMessageManager(MessageManagerProtocol):
         self.answered_callbacks: set[str] = set()
         self.sent_messages = []
         self.last_message_id = 0
+        self.last_reply_markup: (
+            InlineKeyboardMarkup | ReplyKeyboardMarkup | None
+        ) = None
 
     def reset_history(self):
         self.sent_messages.clear()
@@ -128,11 +132,17 @@ class MockMessageManager(MessageManagerProtocol):
                 "text": new_message.text,
             }
 
+        self.last_reply_markup = new_message.reply_markup
+        if isinstance(self.last_reply_markup, ReplyKeyboardMarkup):
+            reply_markup = None
+        else:
+            reply_markup = deepcopy(self.last_reply_markup)
+
         message = Message(
             message_id=message_id,
             date=datetime.now(),
             chat=new_message.chat,
-            reply_markup=deepcopy(new_message.reply_markup),
+            reply_markup=deepcopy(reply_markup),
             **contents,
         )
         self.sent_messages.append(message)

--- a/src/aiogram_dialog/test_tools/mock_message_manager.py
+++ b/src/aiogram_dialog/test_tools/mock_message_manager.py
@@ -67,6 +67,7 @@ class MockMessageManager(MessageManagerProtocol):
     def reset_history(self):
         self.sent_messages.clear()
         self.answered_callbacks.clear()
+        self.last_reply_markup = None
 
     def assert_one_message(self) -> None:
         assert len(self.sent_messages) == 1

--- a/tests/test_reply_keyboard.py
+++ b/tests/test_reply_keyboard.py
@@ -1,0 +1,66 @@
+import pytest
+from aiogram import Dispatcher
+from aiogram.filters import CommandStart
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import CallbackQuery, Message
+
+from aiogram_dialog import (
+    Dialog,
+    DialogManager,
+    StartMode,
+    Window,
+    setup_dialogs,
+)
+from aiogram_dialog.test_tools import BotClient, MockMessageManager
+from aiogram_dialog.test_tools.memory_storage import JsonMemoryStorage
+from aiogram_dialog.widgets.kbd import Button
+from aiogram_dialog.widgets.markup.reply_keyboard import ReplyKeyboardFactory
+from aiogram_dialog.widgets.text import Const
+
+
+class MainSG(StatesGroup):
+    start = State()
+
+
+async def on_click(callback: CallbackQuery, _: Button, manager: DialogManager):
+    middleware_bot = manager.middleware_data["bot"]
+    assert callback.message.bot is middleware_bot
+
+    await manager.done()
+
+
+dialog = Dialog(
+    Window(
+        Const("Hello"),
+        Button(Const("Button"), id="btn", on_click=on_click),
+        state=MainSG.start,
+        markup_factory=ReplyKeyboardFactory(),
+    ),
+)
+
+
+async def start(_: Message, dialog_manager: DialogManager) -> None:
+    await dialog_manager.start(MainSG.start, mode=StartMode.RESET_STACK)
+
+
+@pytest.mark.asyncio
+async def test_reply_keyboard_bot() -> None:
+    dp = Dispatcher(storage=JsonMemoryStorage())
+    dp.include_router(dialog)
+    dp.message.register(start, CommandStart())
+
+    client = BotClient(dp)
+    message_manager = MockMessageManager()
+    setup_dialogs(dp, message_manager=message_manager)
+
+    await client.send("/start")
+    first_message = message_manager.one_message()
+    assert first_message.text == "Hello"
+
+    # click button
+    reply_keyboard = message_manager.last_reply_markup
+    button_text = reply_keyboard.keyboard[0][0].text
+    message_manager.reset_history()
+    await client.send(button_text)
+
+    assert not message_manager.sent_messages


### PR DESCRIPTION
## Description

This PR fixes an issue where `callback.message.bot` was missing for `ReplyCallbackQuery` objects from reply keyboards.

Previously, the simulated message object lacked the associated `Bot` instance due to a missing `.as_(bot)` call, causing errors when accessing `callback.message.bot` in handlers.

Now, the message is correctly linked to the `Bot` instance, ensuring proper context for reply keyboard callbacks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test validating reply-keyboard button interaction and dialog flow.

* **Bug Fixes**
  * Ensured middleware uses the provided bot instance when routing reply-based intents.
  * Improved test message manager to track and reproduce keyboard markup accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->