### PR TITLE
docs: add constructor signatures of some widgets

### DIFF
--- a/docs/widgets/keyboard/button/index.rst
+++ b/docs/widgets/keyboard/button/index.rst
@@ -15,3 +15,8 @@ Unlike normal handlers you should not call callback.answer(), as it is done auto
 .. image:: /resources/button.png
 
 If it is unclear to you where to put button, check :ref:`quickstart`
+
+Classes
+===========
+
+.. autoclass:: aiogram_dialog.widgets.kbd.button.Button

--- a/docs/widgets/keyboard/column/index.rst
+++ b/docs/widgets/keyboard/column/index.rst
@@ -8,3 +8,8 @@ Column
 .. literalinclude:: ./example.py
 
 .. image:: /resources/column.png
+
+Classes
+===========
+
+.. autoclass:: aiogram_dialog.widgets.kbd.group.Column

--- a/docs/widgets/keyboard/copy_text/index.rst
+++ b/docs/widgets/keyboard/copy_text/index.rst
@@ -12,3 +12,8 @@ It requires two text arguments (which can be any text widgets like ``Const`` or 
 .. literalinclude:: ./example.py
 
 .. image:: /resources/copy_text.png
+
+Classes
+===========
+
+.. autoclass:: aiogram_dialog.widgets.kbd.copy.CopyText

--- a/docs/widgets/keyboard/group/index.rst
+++ b/docs/widgets/keyboard/group/index.rst
@@ -14,3 +14,8 @@ Also it can be used to produce rows of fixed width. To do it just set ``width`` 
 .. literalinclude:: ./example_width.py
 
 .. image:: /resources/group_width.png
+
+Classes
+===========
+
+.. autoclass:: aiogram_dialog.widgets.kbd.group.Group

--- a/docs/widgets/keyboard/row/index.rst
+++ b/docs/widgets/keyboard/row/index.rst
@@ -9,3 +9,8 @@ You can place any keyboard widgets inside it (for example buttons or groups) and
 .. literalinclude:: ./example.py
 
 .. image:: /resources/row.png
+
+Classes
+===========
+
+.. autoclass:: aiogram_dialog.widgets.kbd.group.Row

--- a/docs/widgets/keyboard/scrolling_group/index.rst
+++ b/docs/widgets/keyboard/scrolling_group/index.rst
@@ -10,3 +10,9 @@ You can set the ``height`` and ``width`` of the keyboard. If there are not enoug
 
 .. image:: /resources/scrolling_group1.png
 .. image:: /resources/scrolling_group2.png
+
+Classes
+===========
+
+.. autoclass:: aiogram_dialog.widgets.kbd.scrolling_group.ScrollingGroup
+

--- a/docs/widgets/keyboard/switch_inline_query/index.rst
+++ b/docs/widgets/keyboard/switch_inline_query/index.rst
@@ -8,3 +8,8 @@ SwitchInlineQuery is a special kind of inline keyboard button that will prompt t
 You can additionally specify a text that will occur in the query field (e.g. @mytestbot some query)
 
 .. literalinclude:: ./example.py
+
+Classes
+===========
+
+.. autoclass:: aiogram_dialog.widgets.kbd.button.SwitchInlineQuery

--- a/docs/widgets/keyboard/url/index.rst
+++ b/docs/widgets/keyboard/url/index.rst
@@ -10,3 +10,8 @@ Url itself can be any text (including ``Const`` or ``Format``)
 .. literalinclude:: ./example.py
 
 .. image:: /resources/url.png
+
+Classes
+===========
+
+.. autoclass:: aiogram_dialog.widgets.kbd.button.Url


### PR DESCRIPTION
Add constructor signatures of widgets `Button`, `Column`, `CopyText`, `Group`, `Row`, `ScrollingGroup`, `SwitchInlineQuery` and `Url` to docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for keyboard widgets (Button, Column, CopyText, Group, Row, ScrollingGroup, SwitchInlineQuery, and Url) with comprehensive API reference sections. Developers now have quick access to detailed class information, method specifications, and parameter documentation directly within the widget documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->