### PR TITLE
feat: add width_symbols row layout to Group and ScrollingGroup

### DIFF
--- a/docs/widgets/keyboard/group/example_width_symbols.py
+++ b/docs/widgets/keyboard/group/example_width_symbols.py
@@ -1,0 +1,12 @@
+from aiogram_dialog.widgets.kbd import Button, Group
+from aiogram_dialog.widgets.text import Const
+
+# Rows are wrapped by total text length instead of a fixed button count.
+# "Crawl"(5) + "Go"(2) + "Run"(3) = 10 -> first row; "Teleport"(8) -> next row.
+group = Group(
+    Button(Const("Crawl"), id="crawl"),
+    Button(Const("Go"), id="go"),
+    Button(Const("Run"), id="run"),
+    Button(Const("Teleport"), id="tele"),
+    width_symbols=10,
+)

--- a/docs/widgets/keyboard/group/index.rst
+++ b/docs/widgets/keyboard/group/index.rst
@@ -15,6 +15,14 @@ Also it can be used to produce rows of fixed width. To do it just set ``width`` 
 
 .. image:: /resources/group_width.png
 
+Instead of a fixed number of buttons per row, you can wrap rows by the total
+number of characters with ``width_symbols``. Buttons are packed greedily until
+the summed length of their texts would exceed the limit; a button whose text is
+longer than the limit still gets its own row. ``width`` and ``width_symbols``
+are mutually exclusive - setting both raises ``ValueError``.
+
+.. literalinclude:: ./example_width_symbols.py
+
 Classes
 ===========
 

--- a/docs/widgets/keyboard/scrolling_group/index.rst
+++ b/docs/widgets/keyboard/scrolling_group/index.rst
@@ -5,6 +5,8 @@ ScrollingGroup
 
 **ScrollingGroup** widget combines buttons into pages with the ability to scroll forward and backward and go to the last or first page with buttons.
 You can set the ``height`` and ``width`` of the keyboard. If there are not enough buttons for the last page, the keyboard will be filled with empty buttons keeping the specified height and width.
+``ScrollingGroup`` also accepts ``width_symbols`` (forwarded to :ref:`group`),
+wrapping rows by total character count instead of button count.
 
 .. literalinclude:: ./example.py
 

--- a/src/aiogram_dialog/widgets/kbd/group.py
+++ b/src/aiogram_dialog/widgets/kbd/group.py
@@ -15,11 +15,17 @@ class Group(Keyboard):
             *buttons: Keyboard,
             id: str | None = None,
             width: int | None = None,
+            width_symbols: int | None = None,
             when: WhenCondition = None,
     ):
         super().__init__(id=id, when=when)
+        if width is not None and width_symbols is not None:
+            raise ValueError(
+                "Only one of `width` and `width_symbols` can be set",
+            )
         self.buttons = buttons
         self.width = width
+        self.width_symbols = width_symbols
 
     def find(self, widget_id):
         widget = super().find(widget_id)
@@ -39,17 +45,25 @@ class Group(Keyboard):
         kbd: RawKeyboard = []
         for b in self.buttons:
             b_kbd = await b.render_keyboard(data, manager)
-            if self.width is None:
+            if self.width is None and self.width_symbols is None:
                 kbd += b_kbd
             else:
                 if not kbd:
                     kbd.append([])
                 kbd[0].extend(chain.from_iterable(b_kbd))
-        if self.width and kbd:
+        if (self.width or self.width_symbols) and kbd:
             kbd = self._wrap_kbd(kbd[0])
         return kbd
 
     def _wrap_kbd(
+            self,
+            kbd: Iterable[InlineKeyboardButton],
+    ) -> RawKeyboard:
+        if self.width_symbols:
+            return self._wrap_kbd_by_symbols(kbd)
+        return self._wrap_kbd_by_width(kbd)
+
+    def _wrap_kbd_by_width(
             self,
             kbd: Iterable[InlineKeyboardButton],
     ) -> RawKeyboard:
@@ -60,6 +74,26 @@ class Group(Keyboard):
             if len(row) >= self.width:
                 res.append(row)
                 row = []
+        if row:
+            res.append(row)
+        return res
+
+    def _wrap_kbd_by_symbols(
+            self,
+            kbd: Iterable[InlineKeyboardButton],
+    ) -> RawKeyboard:
+        res: RawKeyboard = []
+        row: list[ButtonVariant] = []
+        row_len = 0
+        for b in kbd:
+            b_len = len(b.text)
+            # only wrap a non-empty row, so an over-long button keeps its row
+            if row and row_len + b_len > self.width_symbols:
+                res.append(row)
+                row = []
+                row_len = 0
+            row.append(b)
+            row_len += b_len
         if row:
             res.append(row)
         return res

--- a/src/aiogram_dialog/widgets/kbd/scrolling_group.py
+++ b/src/aiogram_dialog/widgets/kbd/scrolling_group.py
@@ -18,13 +18,17 @@ class ScrollingGroup(Group, BaseScroll):
             *buttons: Keyboard,
             id: str,
             width: int | None = None,
+            width_symbols: int | None = None,
             height: int = 0,
             when: WhenCondition = None,
             on_page_changed: OnPageChangedVariants = None,
             hide_on_single_page: bool = False,
             hide_pager: bool = False,
     ):
-        Group.__init__(self, *buttons, id=id, width=width, when=when)
+        Group.__init__(
+            self, *buttons, id=id, width=width, width_symbols=width_symbols,
+            when=when,
+        )
         BaseScroll.__init__(self, id=id, on_page_changed=on_page_changed)
         self.height = height
         self.hide_on_single_page = hide_on_single_page

--- a/tests/test_width_symbols.py
+++ b/tests/test_width_symbols.py
@@ -1,0 +1,106 @@
+from typing import Any
+
+import pytest
+from aiogram import Dispatcher
+from aiogram.filters import CommandStart
+from aiogram.fsm.state import State, StatesGroup
+
+from aiogram_dialog import (
+    Dialog,
+    DialogManager,
+    StartMode,
+    Window,
+    setup_dialogs,
+)
+from aiogram_dialog.test_tools import BotClient, MockMessageManager
+from aiogram_dialog.test_tools.memory_storage import JsonMemoryStorage
+from aiogram_dialog.widgets.kbd import Button, Group, ScrollingGroup
+from aiogram_dialog.widgets.text import Const
+
+
+def _texts(keyboard) -> list[list[str]]:
+    return [[button.text for button in row] for row in keyboard]
+
+
+def _buttons(texts: list[str]) -> list[Button]:
+    return [
+        Button(Const(text), id=f"b{idx}")
+        for idx, text in enumerate(texts)
+    ]
+
+
+async def _rendered_rows(keyboard) -> list[list[str]]:
+    """Render a keyboard widget through the public dialog path.
+
+    Returns rows as lists of button texts, so tests assert real layout
+    instead of reaching into private wrapping methods.
+    """
+    class RenderSG(StatesGroup):
+        start = State()
+
+    async def start_dialog(event: Any, dialog_manager: DialogManager) -> None:
+        await dialog_manager.start(RenderSG.start, mode=StartMode.RESET_STACK)
+
+    window = Window(Const("stub"), keyboard, state=RenderSG.start)
+    message_manager = MockMessageManager()
+    dp = Dispatcher(storage=JsonMemoryStorage())
+    dp.include_router(Dialog(window))
+    setup_dialogs(dp, message_manager=message_manager)
+    dp.message.register(start_dialog, CommandStart())
+    client = BotClient(dp, chat_id=-1, user_id=1, chat_type="group")
+
+    await client.send("/start")
+    message = message_manager.one_message()
+    return _texts(message.reply_markup.inline_keyboard)
+
+
+def test_both_width_and_symbols_raises():
+    with pytest.raises(ValueError, match="Only one of"):
+        Group(width=2, width_symbols=4)
+
+
+def test_scrolling_group_both_raises():
+    with pytest.raises(ValueError, match="Only one of"):
+        ScrollingGroup(id="s", width=2, width_symbols=4)
+
+
+def test_only_symbols_stored():
+    group = Group(width_symbols=4)
+    assert group.width_symbols == 4
+    assert group.width is None
+
+
+def test_only_width_stored():
+    group = Group(width=2)
+    assert group.width == 2
+    assert group.width_symbols is None
+
+
+@pytest.mark.asyncio
+async def test_symbols_basic_packing():
+    group = Group(*_buttons(["ab", "cd", "ef", "ghijkl"]), width_symbols=4)
+    assert await _rendered_rows(group) == [["ab", "cd"], ["ef"], ["ghijkl"]]
+
+
+@pytest.mark.asyncio
+async def test_symbols_exact_boundary_stays_in_row():
+    group = Group(*_buttons(["ab", "cd"]), width_symbols=4)
+    assert await _rendered_rows(group) == [["ab", "cd"]]
+
+
+@pytest.mark.asyncio
+async def test_symbols_single_button_longer_than_limit():
+    group = Group(*_buttons(["xxxxxx"]), width_symbols=3)
+    assert await _rendered_rows(group) == [["xxxxxx"]]
+
+
+@pytest.mark.asyncio
+async def test_scrolling_group_symbols_wraps():
+    group = ScrollingGroup(
+        *_buttons(["ab", "cd", "ef"]),
+        id="s",
+        width_symbols=4,
+        height=10,
+        hide_pager=True,
+    )
+    assert await _rendered_rows(group) == [["ab", "cd"], ["ef"]]


### PR DESCRIPTION
## Summary

`Group` (and `ScrollingGroup`) wrap rows by a fixed **number of buttons** (`width`). Because Telegram splits a row's width equally between its buttons, rows that mix short and long labels render unevenly - short buttons get too much space, long ones get squeezed.

This PR adds `width_symbols`: wrap rows by the **total number of characters** instead. Buttons are packed greedily into a row until the summed length of their texts would exceed the limit.

## API

```python
Group(*buttons, width_symbols=20)
ScrollingGroup(*buttons, id="sg", width_symbols=20, height=8)
```

- `width` and `width_symbols` are **mutually exclusive** - passing both raises `ValueError`.
- A button whose text is longer than the limit still gets its own row (never dropped).
- `Select` / `Radio` / `Multiselect` get this for free via a wrapping `Group(width_symbols=N)`.

## Implementation

- New optional `width_symbols: int | None` on `Group` and `ScrollingGroup` (forwarded to `Group`).
- `_wrap_kbd` split into a dispatcher plus `_wrap_kbd_by_width` (existing behaviour, unchanged) and `_wrap_kbd_by_symbols`.
- Docs and a runnable example (`example_width_symbols.py`).

## Backward compatibility

Default `width_symbols=None` - output is byte-identical to before. No behaviour change for existing code (including the `width=0` case).

## Tests

`tests/test_width_symbols.py` covers greedy packing, exact-boundary, an over-long single button, mutual exclusion, and `ScrollingGroup` forwarding. All assertions check the rendered layout through the public dialog path. `ruff check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for wrapping keyboard buttons by total text length, alongside fixed column width.
  * Extended scrolling keyboards to use the same layout option.
  * Added documentation and examples showing symbol-based wrapping behavior.

* **Bug Fixes**
  * Prevented using both layout sizing options at once; this now raises a clear error.
  * Improved row wrapping so long button text still appears correctly on its own row when needed.

* **Tests**
  * Added coverage for layout selection, wrapping rules, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->